### PR TITLE
make format_all.jl path independent

### DIFF
--- a/.formatting/format_all.jl
+++ b/.formatting/format_all.jl
@@ -1,6 +1,9 @@
 using JuliaFormatter
 
-not_formatted = format(pwd(); verbose=true)
+# we asume the format_all.jl script is located in QEDbase.jl/.formatting
+project_path = Base.Filesystem.joinpath(Base.Filesystem.dirname(Base.source_path()), "..")
+
+not_formatted = format(project_path; verbose=true)
 if not_formatted
     @info "Formatting verified."
 else

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ format:
   image: julia:1.9
   script:
     - "[[ -d .julia ]] && mv .julia /tmp"
-    - julia --project=.formatting -e 'import Pkg; Pkg.add("JuliaFormatter")'
+    - julia --project=.formatting -e 'import Pkg; Pkg.instantiate()'
     - julia --project=.formatting .formatting/format_all.jl
     - "[[ -d /tmp/.julia ]] && mv /tmp/.julia ."
   variables:


### PR DESCRIPTION
Before the format_all.jl script needs to be execute from the project root directory. Now the script can be executed from every directory path.