### PR TITLE
run unit tests for Julia 1.6 until 1.9

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,7 @@ stages:
   - run_integration_test
   - verify-unit-test-deps
 
-unit_tests_julia1.9:
-  image: julia:1.9
+.untit_test_template:
   stage: unit-test
   script:
     - apt update && apt install -y git
@@ -22,6 +21,46 @@ unit_tests_julia1.9:
     - julia --project=. -e 'import Pkg; Pkg.instantiate()'
     - julia --project=. -e 'import Pkg; Pkg.test(; coverage = true)'
   interruptible: true
+  tags:
+    - cpuonly
+
+unit_tests_releases:
+  extends: .untit_test_template
+  parallel:
+    matrix:
+      - JULIA_VERSION: ["1.6", "1.7", "1.8", "1.9"]
+  image: julia:$JULIA_VERSION
+
+unit_tests_nightly:
+  extends: .untit_test_template
+  # use the same baseimage like the official julia images
+  image: debian:bookworm-slim
+  variables:
+    # path where julia tar bal should be downloaded
+    JULIA_DONWLOAD: /julia/download
+    # path where julia should be extracted
+    JULIA_EXTRACT: /julia/extract
+  before_script:
+    - apt update && apt install -y wget
+    - mkdir -p $JULIA_DONWLOAD
+    - mkdir -p $JULIA_EXTRACT
+    - >
+      if [[ $CI_RUNNER_EXECUTABLE_ARCH == "linux/arm64" ]]; then
+        wget https://julialangnightlies-s3.julialang.org/bin/linux/aarch64/julia-latest-linux-aarch64.tar.gz -O $JULIA_DONWLOAD/julia-nightly.tar.gz
+      elif [[ $CI_RUNNER_EXECUTABLE_ARCH == "linux/amd64" ]]; then
+        wget https://julialangnightlies-s3.julialang.org/bin/linux/x86_64/julia-latest-linux-x86_64.tar.gz -O $JULIA_DONWLOAD/julia-nightly.tar.gz
+      else
+        echo "unknown runner architecture -> $CI_RUNNER_EXECUTABLE_ARCH"
+        exit 1
+      fi
+    - tar -xf $JULIA_DONWLOAD/julia-nightly.tar.gz -C $JULIA_EXTRACT
+    # we need to search for the julia base folder name, because the second part of the name is the git commit hash
+    # e.g. julia-b0c6781676f
+    - JULIA_EXTRACT_FOLDER=${JULIA_EXTRACT}/$(ls $JULIA_EXTRACT | grep -m1 julia)
+    # copy everything to /usr to make julia public available
+    # mv is not possible, because it cannot merge folder
+    - cp -r $JULIA_EXTRACT_FOLDER/* /usr
+  allow_failure: true
   tags:
     - cpuonly
 


### PR DESCRIPTION
- tests also the latest unreleased version 1.10 (can fail)
- integration tests still testing a single version. Will be extended in another PR.