### PR TITLE
[DO NOT MERGE] test integration test with different Julia versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,9 @@ generate_integration_tests:
     - export CI_DEPENDENCY_NAME=$(cat $CI_PROJECT_DIR/Project.toml | grep name | awk '{ print $3 }' | tr -d '"')
     - echo "CI_DEPENDENCY_NAME -> $CI_DEPENDENCY_NAME"
     - apt update && apt install -y git
-    - git clone --depth 1 -b dev https://github.com/QEDjl-project/QED.jl.git /QEDjl
+    #- git clone --depth 1 -b dev https://github.com/QEDjl-project/QED.jl.git /QEDjl
+    # only for testing purpose
+    - git clone --depth 1 -b IntegrationTestVersioning https://github.com/SimeonEhrig/QED.jl.git /QEDjl
     - cd /QEDjl/.ci/integTestGen/
     # use local registry of the QED project
     - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/QEDjl-project/registry.git"));'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ generate_integration_tests:
     - apt update && apt install -y git
     #- git clone --depth 1 -b dev https://github.com/QEDjl-project/QED.jl.git /QEDjl
     # only for testing purpose
-    - git clone --depth 1 -b IntegrationTestVersioning https://github.com/SimeonEhrig/QED.jl.git /QEDjl
+    - git clone --depth 1 -b useDevDepsIntegrationTestGen https://github.com/SimeonEhrig/QED.jl.git /QEDjl
     - cd /QEDjl/.ci/integTestGen/
     # use local registry of the QED project
     - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/QEDjl-project/registry.git"));'


### PR DESCRIPTION
This PR only tests, if [this PR from QED.jl](https://github.com/QEDjl-project/QED.jl/pull/16) is working and if the integration tests passes with Julia 1.6 until 1.9.

If https://github.com/QEDjl-project/QED.jl/pull/16 was merged, all QED projects does automatically run integration tests with different Julia versions.