### PR TITLE
Improve parameter coverage in particle unit test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,8 @@ StaticArrays = "1.2.13"
 julia = "1.6"
 
 [extras]
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["SafeTestsets","Test"]

--- a/src/particles/particle_states.jl
+++ b/src/particles/particle_states.jl
@@ -228,8 +228,8 @@ end
 function _photon_state(pol::AllPolarization, mom::QEDbase.AbstractFourMomentum)
     cth = getCosTheta(mom)
     sth = sqrt(1 - cth^2)
-    sin_phi = getSinPhi(mom)
-    cos_phi = sqrt(1 - sin_phi^2)
+    cos_phi = getCosPhi(mom) 
+    sin_phi = getSinPhi(mom) 
     return SVector(
         SLorentzVector{Float64}(0.0, cth * cos_phi, cth * sin_phi, -sth),
         SLorentzVector{Float64}(0.0, -sin_phi, cos_phi, 0.0),
@@ -239,14 +239,14 @@ end
 function _photon_state(pol::PolarizationX, mom::QEDbase.AbstractFourMomentum)
     cth = getCosTheta(mom)
     sth = sqrt(1 - cth^2)
-    sin_phi = getSinPhi(mom)
-    cos_phi = sqrt(1 - sin_phi^2)
+    cos_phi = getCosPhi(mom) 
+    sin_phi = getSinPhi(mom) 
     return SLorentzVector{Float64}(0.0, cth * cos_phi, cth * sin_phi, -sth)
 end
 
 function _photon_state(pol::PolarizationY, mom::QEDbase.AbstractFourMomentum)
-    sin_phi = getSinPhi(mom)
-    cos_phi = sqrt(1 - sin_phi^2)
+    cos_phi = getCosPhi(mom) 
+    sin_phi = getSinPhi(mom) 
     return SLorentzVector{Float64}(0.0, -sin_phi, cos_phi, 0.0)
 end
 

--- a/src/particles/particle_states.jl
+++ b/src/particles/particle_states.jl
@@ -228,8 +228,8 @@ end
 function _photon_state(pol::AllPolarization, mom::QEDbase.AbstractFourMomentum)
     cth = getCosTheta(mom)
     sth = sqrt(1 - cth^2)
-    cos_phi = getCosPhi(mom) 
-    sin_phi = getSinPhi(mom) 
+    cos_phi = getCosPhi(mom)
+    sin_phi = getSinPhi(mom)
     return SVector(
         SLorentzVector{Float64}(0.0, cth * cos_phi, cth * sin_phi, -sth),
         SLorentzVector{Float64}(0.0, -sin_phi, cos_phi, 0.0),
@@ -239,14 +239,14 @@ end
 function _photon_state(pol::PolarizationX, mom::QEDbase.AbstractFourMomentum)
     cth = getCosTheta(mom)
     sth = sqrt(1 - cth^2)
-    cos_phi = getCosPhi(mom) 
-    sin_phi = getSinPhi(mom) 
+    cos_phi = getCosPhi(mom)
+    sin_phi = getSinPhi(mom)
     return SLorentzVector{Float64}(0.0, cth * cos_phi, cth * sin_phi, -sth)
 end
 
 function _photon_state(pol::PolarizationY, mom::QEDbase.AbstractFourMomentum)
-    cos_phi = getCosPhi(mom) 
-    sin_phi = getSinPhi(mom) 
+    cos_phi = getCosPhi(mom)
+    sin_phi = getSinPhi(mom)
     return SLorentzVector{Float64}(0.0, -sin_phi, cos_phi, 0.0)
 end
 

--- a/test/dirac_tensor.jl
+++ b/test/dirac_tensor.jl
@@ -1,4 +1,4 @@
-
+using QEDbase
 using StaticArrays
 
 unary_methods = [-, +]

--- a/test/four_momentum.jl
+++ b/test/four_momentum.jl
@@ -1,3 +1,4 @@
+using QEDbase
 using Random
 
 const ATOL = 1e-15

--- a/test/gamma_matrices.jl
+++ b/test/gamma_matrices.jl
@@ -1,4 +1,4 @@
-
+using QEDbase
 using LinearAlgebra
 using Random
 using SparseArrays

--- a/test/lorentz_interface.jl
+++ b/test/lorentz_interface.jl
@@ -1,3 +1,4 @@
+using QEDbase
 
 lorentz_getter = [
     getT,

--- a/test/lorentz_vector.jl
+++ b/test/lorentz_vector.jl
@@ -1,3 +1,4 @@
+using QEDbase
 using StaticArrays
 
 unary_methods = [-, +]

--- a/test/particle_spinors.jl
+++ b/test/particle_spinors.jl
@@ -1,3 +1,4 @@
+using QEDbase
 using Random
 
 const ATOL = 1e-15

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -1,4 +1,5 @@
 using QEDbase
+using StaticArrays
 using Random
 
 include("utils.jl")
@@ -12,7 +13,7 @@ FERMION_STATES_GROUNDTRUTH_FACTORY = Dict(
 
 RNG = MersenneTwister(708583836976)
 ATOL = eps()
-RTOL = sqrt(eps())
+RTOL = 0.0
 PHOTON_ENERGIES = (0.0, rand(RNG), rand(RNG) * 10)
 COS_THETAS = (-1.0, -rand(RNG), 0.0, rand(RNG), 1.0)
 # check every quadrant

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -13,7 +13,7 @@ FERMION_STATES_GROUNDTRUTH_FACTORY = Dict(
 RNG = MersenneTwister(708583836976)
 ATOL = eps()
 RTOL = sqrt(eps())
-PHOTON_ENERGIES = (0.0,rand(RNG), rand(RNG)*10,rand(RNG)*1e2,rand(RNG)*1e3)
+PHOTON_ENERGIES = (0.0,rand(RNG), rand(RNG)*10)
 COS_THETAS = (-1.0,-rand(RNG),0.0,rand(RNG),1.0)
 # check every quadrant
 PHIS = (0.0,rand(RNG)*pi/2,pi/2,(1.0+rand(RNG))*pi/2,pi,(2+rand(RNG))*pi/2,3*pi/2, (3+rand(RNG))*pi/2, 2*pi)
@@ -27,10 +27,10 @@ X,Y,Z = rand(RNG,3)
         @test is_particle(TestFermion())
         @test !is_anti_particle(TestFermion())
 
-        mom = SFourMomentum(sqrt(mass(p) + X^2 + Y^2 + Z^2))
         @testset "$p $d" for (p, d) in
             Iterators.product((Electron, Positron), (Incoming, Outgoing))
 
+            mom = SFourMomentum(sqrt(mass(p()) + X^2 + Y^2 + Z^2),X,Y,Z)
             particle_mass = mass(p())
             groundtruth_states = FERMION_STATES_GROUNDTRUTH_FACTORY[(d, p)](
                 mom, particle_mass
@@ -122,6 +122,7 @@ end
     @testset "$D" for D in [Incoming, Outgoing]
 
         @testset "$om $cth $phi" for (om,cth,phi) in Iterators.product(PHOTON_ENERGIES,COS_THETAS,PHIS)
+        #@testset "$x $y $z" for (x,y,z) in Iterators.product(X_arr,Y_arr,Z_arr)
 
             mom = SFourMomentum(_cartesian_coordinates(om,om,cth,phi))
             both_photon_states = base_state(Photon(), D(), mom, AllPolarization())

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -13,12 +13,22 @@ FERMION_STATES_GROUNDTRUTH_FACTORY = Dict(
 RNG = MersenneTwister(708583836976)
 ATOL = eps()
 RTOL = sqrt(eps())
-PHOTON_ENERGIES = (0.0,rand(RNG), rand(RNG)*10)
-COS_THETAS = (-1.0,-rand(RNG),0.0,rand(RNG),1.0)
+PHOTON_ENERGIES = (0.0, rand(RNG), rand(RNG) * 10)
+COS_THETAS = (-1.0, -rand(RNG), 0.0, rand(RNG), 1.0)
 # check every quadrant
-PHIS = (0.0,rand(RNG)*pi/2,pi/2,(1.0+rand(RNG))*pi/2,pi,(2+rand(RNG))*pi/2,3*pi/2, (3+rand(RNG))*pi/2, 2*pi)
+PHIS = (
+    0.0,
+    rand(RNG) * pi / 2,
+    pi / 2,
+    (1.0 + rand(RNG)) * pi / 2,
+    pi,
+    (2 + rand(RNG)) * pi / 2,
+    3 * pi / 2,
+    (3 + rand(RNG)) * pi / 2,
+    2 * pi,
+)
 
-X,Y,Z = rand(RNG,3)
+X, Y, Z = rand(RNG, 3)
 
 @testset "fermion likes" begin
     @testset "fermion" begin
@@ -28,9 +38,8 @@ X,Y,Z = rand(RNG,3)
         @test !is_anti_particle(TestFermion())
 
         @testset "$p $d" for (p, d) in
-            Iterators.product((Electron, Positron), (Incoming, Outgoing))
-
-            mom = SFourMomentum(sqrt(mass(p()) + X^2 + Y^2 + Z^2),X,Y,Z)
+                             Iterators.product((Electron, Positron), (Incoming, Outgoing))
+            mom = SFourMomentum(sqrt(mass(p()) + X^2 + Y^2 + Z^2), X, Y, Z)
             particle_mass = mass(p())
             groundtruth_states = FERMION_STATES_GROUNDTRUTH_FACTORY[(d, p)](
                 mom, particle_mass
@@ -40,9 +49,9 @@ X,Y,Z = rand(RNG,3)
             @test base_state(p(), d(), mom, SpinUp()) == groundtruth_tuple[1]
             @test base_state(p(), d(), mom, SpinDown()) == groundtruth_tuple[2]
 
-            @test QEDbase._as_svec(base_state(p(), d(), mom, AllSpin())) isa SVector 
-            @test QEDbase._as_svec(base_state(p(), d(), mom, SpinUp())) isa SVector 
-            @test QEDbase._as_svec(base_state(p(), d(), mom, SpinDown())) isa SVector 
+            @test QEDbase._as_svec(base_state(p(), d(), mom, AllSpin())) isa SVector
+            @test QEDbase._as_svec(base_state(p(), d(), mom, SpinUp())) isa SVector
+            @test QEDbase._as_svec(base_state(p(), d(), mom, SpinDown())) isa SVector
 
             @test QEDbase._as_svec(base_state(p(), d(), mom, AllSpin())) ==
                 groundtruth_tuple
@@ -108,7 +117,6 @@ end
         @test is_particle(TestMajoranaBoson())
         @test is_anti_particle(TestMajoranaBoson())
     end
-
 end
 
 @testset "photon" begin
@@ -120,20 +128,25 @@ end
     @test mass(Photon()) == 0.0
 
     @testset "$D" for D in [Incoming, Outgoing]
+        @testset "$om $cth $phi" for (om, cth, phi) in
+                                     Iterators.product(PHOTON_ENERGIES, COS_THETAS, PHIS)
+            #@testset "$x $y $z" for (x,y,z) in Iterators.product(X_arr,Y_arr,Z_arr)
 
-        @testset "$om $cth $phi" for (om,cth,phi) in Iterators.product(PHOTON_ENERGIES,COS_THETAS,PHIS)
-        #@testset "$x $y $z" for (x,y,z) in Iterators.product(X_arr,Y_arr,Z_arr)
-
-            mom = SFourMomentum(_cartesian_coordinates(om,om,cth,phi))
+            mom = SFourMomentum(_cartesian_coordinates(om, om, cth, phi))
             both_photon_states = base_state(Photon(), D(), mom, AllPolarization())
 
             # property test the photon states
             @test isapprox((both_photon_states[1] * mom), 0.0, atol=ATOL, rtol=RTOL)
             @test isapprox((both_photon_states[2] * mom), 0.0, atol=ATOL, rtol=RTOL)
-            @test isapprox((both_photon_states[1] * both_photon_states[1]), -1.0, atol=ATOL, rtol=RTOL)
-            @test isapprox((both_photon_states[2] * both_photon_states[2]), -1.0, atol=ATOL, rtol=RTOL)
-            @test isapprox((both_photon_states[1] * both_photon_states[2]), 0.0, atol=ATOL, rtol=RTOL)
-
+            @test isapprox(
+                (both_photon_states[1] * both_photon_states[1]), -1.0, atol=ATOL, rtol=RTOL
+            )
+            @test isapprox(
+                (both_photon_states[2] * both_photon_states[2]), -1.0, atol=ATOL, rtol=RTOL
+            )
+            @test isapprox(
+                (both_photon_states[1] * both_photon_states[2]), 0.0, atol=ATOL, rtol=RTOL
+            )
 
             # test the single polarization states
             @test base_state(Photon(), D(), mom, PolarizationX()) == both_photon_states[1]
@@ -156,4 +169,3 @@ end
         end
     end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,32 @@
 using QEDbase
 using Test
+using SafeTestsets
 
-@testset "QEDbase.jl" begin
-    include("dirac_tensor.jl")
-    include("lorentz_vector.jl")
-    include("lorentz_interface.jl")
+begin
+    @time @safetestset "Dirac tensors" begin    
+        include("dirac_tensor.jl")
+    end
+        
+    @time @safetestset "Lorentz Vectors" begin    
+        include("lorentz_vector.jl")
+    end
+        
+    @time @safetestset "Lorentz interface" begin    
+        include("lorentz_interface.jl")
+    end
+    @time @safetestset "Gamma matrices" begin    
+        include("gamma_matrices.jl")
+    end
 
-    include("gamma_matrices.jl")
+    @time @safetestset "particle spinors" begin    
+        include("particle_spinors.jl")
+    end
+        
+    @time @safetestset "four momentum" begin    
+        include("four_momentum.jl")
+    end
 
-    include("particle_spinors.jl")
-    include("four_momentum.jl")
-
-    include("particles.jl")
+    @time @safetestset "particles" begin    
+        include("particles.jl")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,30 +3,30 @@ using Test
 using SafeTestsets
 
 begin
-    @time @safetestset "Dirac tensors" begin    
+    @time @safetestset "Dirac tensors" begin
         include("dirac_tensor.jl")
     end
-        
-    @time @safetestset "Lorentz Vectors" begin    
+
+    @time @safetestset "Lorentz Vectors" begin
         include("lorentz_vector.jl")
     end
-        
-    @time @safetestset "Lorentz interface" begin    
+
+    @time @safetestset "Lorentz interface" begin
         include("lorentz_interface.jl")
     end
-    @time @safetestset "Gamma matrices" begin    
+    @time @safetestset "Gamma matrices" begin
         include("gamma_matrices.jl")
     end
 
-    @time @safetestset "particle spinors" begin    
+    @time @safetestset "particle spinors" begin
         include("particle_spinors.jl")
     end
-        
-    @time @safetestset "four momentum" begin    
+
+    @time @safetestset "four momentum" begin
         include("four_momentum.jl")
     end
 
-    @time @safetestset "particles" begin    
+    @time @safetestset "particles" begin
         include("particles.jl")
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -4,8 +4,8 @@ Returns the cartesian coordinates (E,px,py,pz) for given spherical coordiantes
 (E, rho, cos_theta, phi), where rho denotes the length of the respective three-momentum, 
 theta is the polar- and phi the azimuthal angle. 
 """
-function _cartesian_coordinates(E,rho,cth,phi)
-    sth = sqrt(1-cth^2)
-    sphi,cphi = sincos(phi)
-    return (E,rho*sth*cphi,rho*sth*sphi,rho*cth)
+function _cartesian_coordinates(E, rho, cth, phi)
+    sth = sqrt(1 - cth^2)
+    sphi, cphi = sincos(phi)
+    return (E, rho * sth * cphi, rho * sth * sphi, rho * cth)
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,11 @@
+"""
+
+Returns the cartesian coordinates (E,px,py,pz) for given spherical coordiantes
+(E, rho, cos_theta, phi), where rho denotes the length of the respective three-momentum, 
+theta is the polar- and phi the azimuthal angle. 
+"""
+function _cartesian_coordinates(E,rho,cth,phi)
+    sth = sqrt(1-cth^2)
+    sphi,cphi = sincos(phi)
+    return (E,rho*sth*cphi,rho*sth*sphi,rho*cth)
+end


### PR DESCRIPTION
This PR improves the coverage for coordinates tested in `test/particle.jl` to the full domains for angles in spherical coordinates for photons. 

### Summary

- added safetestsets to modulize the unit tests
- added more cases for the angles in spherical coordinates
- added a fix for #49 


This resolves #49 
