### PR TITLE
Scalar broadcasting for Particles, Directions, Spins and Polarization

### DIFF
--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -25,6 +25,7 @@ The second type of functions define a hard interface for `AbstractParticle`:
 These functions must be implemented in order to have the subtype of `AbstractParticle` work with the functionalities of `QEDprocesses.jl`.
 """
 abstract type AbstractParticle end
+Base.broadcastable(part::AbstractParticle) = Ref(part)
 
 """
     $(TYPEDSIGNATURES)

--- a/src/particles/particle_direction.jl
+++ b/src/particles/particle_direction.jl
@@ -2,6 +2,7 @@
 Abstract base type for the directions of particles in the context of processes, i.e. either they are *incoming* or *outgoing*. Subtypes of this are mostly used for dispatch.
 """
 abstract type ParticleDirection end
+Base.broadcastable(dir::ParticleDirection) = Ref(dir)
 
 """
     Incoming <: ParticleDirection

--- a/src/particles/particle_spin_pol.jl
+++ b/src/particles/particle_spin_pol.jl
@@ -2,6 +2,7 @@
 Abstract base type for the spin or polarization of [`FermionLike`](@ref) or [`BosonLike`](@ref) particles, respectively.
 """
 abstract type AbstractSpinOrPolarization end
+Base.broadcastable(spin_or_pol::AbstractSpinOrPolarization) = Ref(spin_or_pol)
 
 """
 Abstract base type for the spin of [`FermionLike`](@ref) particles.

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -38,7 +38,7 @@ test_broadcast(x::AbstractSpinOrPolarization) = x
 
 @testset "scalar broadcasting" begin
     @testset "directions" begin
-        @testset "dir" for dir in (Incoming(), Outgoing())
+        @testset "$dir" for dir in (Incoming(), Outgoing())
             @test test_broadcast.(dir) == dir
         end
     end

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -34,11 +34,22 @@ X, Y, Z = rand(RNG, 3)
 # test function to test scalar broadcasting
 test_broadcast(x::AbstractParticle) = x
 test_broadcast(x::ParticleDirection) = x
+test_broadcast(x::AbstractSpinOrPolarization) = x
 
-@testset "broadcast directions" begin
-    @testset "dir" for dir in (Incoming(),Outgoing())
-        @test test_broadcast.(dir) == dir
+
+@testset "scalar broadcasting" begin
+    @testset "directions" begin
+        @testset "dir" for dir in (Incoming(),Outgoing())
+            @test test_broadcast.(dir) == dir
+        end
     end
+
+    @testset "spins and polarization" begin
+        @testset "spin_or_pol" for spin_or_pol in (SpinUp(),SpinDown(),AllSpin(),PolX(),PolY(),AllPol())
+            @test test_broadcast.(spin_or_pol) == spin_or_pol 
+        end
+    end
+
 end
 
 @testset "fermion likes" begin

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -31,12 +31,16 @@ PHIS = (
 
 X, Y, Z = rand(RNG, 3)
 
+# test function to test scalar broadcasting
+test_broadcast(x::AbstractParticle) = x
+
 @testset "fermion likes" begin
     @testset "fermion" begin
         struct TestFermion <: Fermion end
         @test is_fermion(TestFermion())
         @test is_particle(TestFermion())
         @test !is_anti_particle(TestFermion())
+        @test test_broadcast.(TestFermion()) == TestFermion()
 
         @testset "$p $d" for (p, d) in
                              Iterators.product((Electron, Positron), (Incoming, Outgoing))
@@ -68,6 +72,7 @@ X, Y, Z = rand(RNG, 3)
         @test is_fermion(TestAntiFermion())
         @test !is_particle(TestAntiFermion())
         @test is_anti_particle(TestAntiFermion())
+        @test test_broadcast.(TestAntiFermion()) == TestAntiFermion()
     end
 
     @testset "majorana fermion" begin
@@ -75,6 +80,7 @@ X, Y, Z = rand(RNG, 3)
         @test is_fermion(TestMajoranaFermion())
         @test is_particle(TestMajoranaFermion())
         @test is_anti_particle(TestMajoranaFermion())
+        @test test_broadcast.(TestMajoranaFermion()) == TestMajoranaFermion()
     end
 
     @testset "electron" begin
@@ -83,6 +89,7 @@ X, Y, Z = rand(RNG, 3)
         @test !is_anti_particle(Electron())
         @test mass(Electron()) == 1.0
         @test charge(Electron()) == -1.0
+        @test test_broadcast.(Electron()) == Electron()
     end
 
     @testset "positron" begin
@@ -91,6 +98,7 @@ X, Y, Z = rand(RNG, 3)
         @test is_anti_particle(Positron())
         @test mass(Positron()) == 1.0
         @test charge(Positron()) == 1.0
+        @test test_broadcast.(Positron()) == Positron()
     end
 end
 
@@ -101,6 +109,7 @@ end
         @test is_boson(TestBoson())
         @test is_particle(TestBoson())
         @test !is_anti_particle(TestBoson())
+        @test test_broadcast.(TestBoson()) == TestBoson()
     end
 
     @testset "antiboson" begin
@@ -109,6 +118,7 @@ end
         @test is_boson(TestAntiBoson())
         @test !is_particle(TestAntiBoson())
         @test is_anti_particle(TestAntiBoson())
+        @test test_broadcast.(TestAntiBoson()) == TestAntiBoson()
     end
 
     @testset "majorana boson" begin
@@ -117,6 +127,7 @@ end
         @test is_boson(TestMajoranaBoson())
         @test is_particle(TestMajoranaBoson())
         @test is_anti_particle(TestMajoranaBoson())
+        @test test_broadcast.(TestMajoranaBoson()) == TestMajoranaBoson()
     end
 end
 
@@ -127,6 +138,7 @@ end
     @test is_anti_particle(Photon())
     @test charge(Photon()) == 0.0
     @test mass(Photon()) == 0.0
+    @test test_broadcast.(Photon()) == Photon()
 
     @testset "$D" for D in [Incoming, Outgoing]
         @testset "$om $cth $phi" for (om, cth, phi) in

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -44,7 +44,7 @@ test_broadcast(x::AbstractSpinOrPolarization) = x
     end
 
     @testset "spins and polarization" begin
-        @testset "spin_or_pol" for spin_or_pol in (
+        @testset "$spin_or_pol" for spin_or_pol in (
             SpinUp(), SpinDown(), AllSpin(), PolX(), PolY(), AllPol()
         )
             @test test_broadcast.(spin_or_pol) == spin_or_pol

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -36,20 +36,20 @@ test_broadcast(x::AbstractParticle) = x
 test_broadcast(x::ParticleDirection) = x
 test_broadcast(x::AbstractSpinOrPolarization) = x
 
-
 @testset "scalar broadcasting" begin
     @testset "directions" begin
-        @testset "dir" for dir in (Incoming(),Outgoing())
+        @testset "dir" for dir in (Incoming(), Outgoing())
             @test test_broadcast.(dir) == dir
         end
     end
 
     @testset "spins and polarization" begin
-        @testset "spin_or_pol" for spin_or_pol in (SpinUp(),SpinDown(),AllSpin(),PolX(),PolY(),AllPol())
-            @test test_broadcast.(spin_or_pol) == spin_or_pol 
+        @testset "spin_or_pol" for spin_or_pol in (
+            SpinUp(), SpinDown(), AllSpin(), PolX(), PolY(), AllPol()
+        )
+            @test test_broadcast.(spin_or_pol) == spin_or_pol
         end
     end
-
 end
 
 @testset "fermion likes" begin

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -33,6 +33,13 @@ X, Y, Z = rand(RNG, 3)
 
 # test function to test scalar broadcasting
 test_broadcast(x::AbstractParticle) = x
+test_broadcast(x::ParticleDirection) = x
+
+@testset "broadcast directions" begin
+    @testset "dir" for dir in (Incoming(),Outgoing())
+        @test test_broadcast.(dir) == dir
+    end
+end
 
 @testset "fermion likes" begin
     @testset "fermion" begin


### PR DESCRIPTION
We add scalar broadcasting for `AbstractParticle`, `ParticleDirection`, and `AbstractSpinOrPolarization`. For instance, if one has a function `func(spin::SpinUp,x::Real)` and wants to perform a broadcast over `x`, one can now do 

```julia
x_vec = rand(10)
func.(SpinUp(),x_vec)
```

instead of `func.(Ref(SpinUp()),x_vec)`. 