### PR TITLE
Number of spins or pols

### DIFF
--- a/src/QEDbase.jl
+++ b/src/QEDbase.jl
@@ -62,6 +62,8 @@ export AbstractDefinitePolarization, AbstractIndefinitePolarization
 export PolarizationX, PolX, PolarizationY, PolY, AllPolarization, AllPol
 export AbstractDefiniteSpin, AbstractIndefiniteSpin
 export SpinUp, SpinDown, AllSpin
+export number_of_spin_pol 
+
 
 using StaticArrays
 using LinearAlgebra

--- a/src/QEDbase.jl
+++ b/src/QEDbase.jl
@@ -62,8 +62,7 @@ export AbstractDefinitePolarization, AbstractIndefinitePolarization
 export PolarizationX, PolX, PolarizationY, PolY, AllPolarization, AllPol
 export AbstractDefiniteSpin, AbstractIndefiniteSpin
 export SpinUp, SpinDown, AllSpin
-export number_of_spin_pol 
-
+export number_of_spin_pol
 
 using StaticArrays
 using LinearAlgebra

--- a/src/QEDbase.jl
+++ b/src/QEDbase.jl
@@ -62,7 +62,7 @@ export AbstractDefinitePolarization, AbstractIndefinitePolarization
 export PolarizationX, PolX, PolarizationY, PolY, AllPolarization, AllPol
 export AbstractDefiniteSpin, AbstractIndefiniteSpin
 export SpinUp, SpinDown, AllSpin
-export number_of_spin_pol
+export multiplicity
 
 using StaticArrays
 using LinearAlgebra

--- a/src/particles/particle_spin_pol.jl
+++ b/src/particles/particle_spin_pol.jl
@@ -177,3 +177,18 @@ y-polarized
 struct PolarizationY <: AbstractDefinitePolarization end
 const PolY = PolarizationY
 Base.show(io::IO, ::MIME"text/plain", ::PolY) = print(io, "y-polarized")
+
+"""
+    number_of_spin_pol(spin_or_pol)
+
+Return the number of spins or polarizations respresented by `spin_or_pol`, e.g. `number_of_spin_pol(SpinUp()) == 1`.
+
+"""
+function number_of_spin_pol end
+number_of_spin_pol(::AbstractDefinitePolarization) = 1
+number_of_spin_pol(::AbstractDefiniteSpin) = 1
+number_of_spin_pol(::AbstractIndefinitePolarization) = 2
+number_of_spin_pol(::AbstractIndefiniteSpin) = 2
+
+
+

--- a/src/particles/particle_spin_pol.jl
+++ b/src/particles/particle_spin_pol.jl
@@ -179,13 +179,13 @@ const PolY = PolarizationY
 Base.show(io::IO, ::MIME"text/plain", ::PolY) = print(io, "y-polarized")
 
 """
-    number_of_spin_pol(spin_or_pol)
+    multiplicity(spin_or_pol)
 
-Return the number of spins or polarizations respresented by `spin_or_pol`, e.g. `number_of_spin_pol(SpinUp()) == 1`.
+Return the number of spins or polarizations respresented by `spin_or_pol`, e.g. `multiplicity(SpinUp()) == 1`, but `multiplicity(AllSpin()) = 2`.
 
 """
-function number_of_spin_pol end
-number_of_spin_pol(::AbstractDefinitePolarization) = 1
-number_of_spin_pol(::AbstractDefiniteSpin) = 1
-number_of_spin_pol(::AbstractIndefinitePolarization) = 2
-number_of_spin_pol(::AbstractIndefiniteSpin) = 2
+function multiplicity end
+multiplicity(::AbstractDefinitePolarization) = 1
+multiplicity(::AbstractDefiniteSpin) = 1
+multiplicity(::AbstractIndefinitePolarization) = 2
+multiplicity(::AbstractIndefiniteSpin) = 2

--- a/src/particles/particle_spin_pol.jl
+++ b/src/particles/particle_spin_pol.jl
@@ -189,6 +189,3 @@ number_of_spin_pol(::AbstractDefinitePolarization) = 1
 number_of_spin_pol(::AbstractDefiniteSpin) = 1
 number_of_spin_pol(::AbstractIndefinitePolarization) = 2
 number_of_spin_pol(::AbstractIndefiniteSpin) = 2
-
-
-

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -52,15 +52,15 @@ test_broadcast(x::AbstractSpinOrPolarization) = x
     end
 end
 
-@testset "number of spins or pols" begin
+@testset "multiplicity of spins or pols" begin
     @testset "single" begin
         @testset "$spin_or_pol" for spin_or_pol in (SpinUp(), SpinDown(), PolX(), PolY())
-            @test number_of_spin_pol(spin_or_pol) == 1
+            @test multiplicity(spin_or_pol) == 1
         end
     end
     @testset "multiple" begin
         @testset "$spin_or_pol" for spin_or_pol in (AllSpin(), AllPol())
-            @test number_of_spin_pol(spin_or_pol) == 2
+            @test multiplicity(spin_or_pol) == 2
         end
     end
 end

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -54,12 +54,12 @@ end
 
 @testset "number of spins or pols" begin
     @testset "single" begin
-        @testset "$spin_or_pol" for spin_or_pol in (SpinUp(),SpinDown(),PolX(),PolY())
+        @testset "$spin_or_pol" for spin_or_pol in (SpinUp(), SpinDown(), PolX(), PolY())
             @test number_of_spin_pol(spin_or_pol) == 1
         end
     end
     @testset "multiple" begin
-        @testset "$spin_or_pol" for spin_or_pol in (AllSpin(),AllPol())
+        @testset "$spin_or_pol" for spin_or_pol in (AllSpin(), AllPol())
             @test number_of_spin_pol(spin_or_pol) == 2
         end
     end

--- a/test/particles.jl
+++ b/test/particles.jl
@@ -52,6 +52,19 @@ test_broadcast(x::AbstractSpinOrPolarization) = x
     end
 end
 
+@testset "number of spins or pols" begin
+    @testset "single" begin
+        @testset "$spin_or_pol" for spin_or_pol in (SpinUp(),SpinDown(),PolX(),PolY())
+            @test number_of_spin_pol(spin_or_pol) == 1
+        end
+    end
+    @testset "multiple" begin
+        @testset "$spin_or_pol" for spin_or_pol in (AllSpin(),AllPol())
+            @test number_of_spin_pol(spin_or_pol) == 2
+        end
+    end
+end
+
 @testset "fermion likes" begin
     @testset "fermion" begin
         struct TestFermion <: Fermion end


### PR DESCRIPTION
Added convenience function for the number of (definite) spins or pols represented by the respective type. For instance, `SpinUp()` represents one spin instance, whereas `AllSpin()` represents two. 