### PR TITLE
BiSpinor multiplication fix for GPU

### DIFF
--- a/src/dirac_tensors.jl
+++ b/src/dirac_tensors.jl
@@ -92,7 +92,7 @@ Tensor product of an adjoint with a standard bi-spinor resulting in a scalar.
 
 """
 function mul(aBS::AdjointBiSpinor, BS::BiSpinor)::ComplexF64
-    return transpose(aBS) * BS
+    return aBS.el1 * BS.el1 + aBS.el2 * BS.el2 + aBS.el3 * BS.el3 + aBS.el4 * BS.el4
 end
 @inline *(aBS::AdjointBiSpinor, BS::BiSpinor) = mul(aBS::AdjointBiSpinor, BS::BiSpinor)
 


### PR DESCRIPTION
Just a tiny for multiplication of BiSpinor * AdjointBiSpinor on GPU. The general dot product doesn't work on the GPU.