### PR TITLE
removed ConstructionBase from dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,6 @@ version = "0.2.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
-ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PhysicalConstants = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"

--- a/src/QEDbase.jl
+++ b/src/QEDbase.jl
@@ -86,7 +86,7 @@ using DocStringExtensions
 
 using SimpleTraits
 using ArgCheck
-using ConstructionBase
+#using ConstructionBase
 
 include("errors.jl")
 include("utils.jl")


### PR DESCRIPTION
During the registration, auto-merge is blocked due to compatibility problems with `ConstructionBase`. See https://github.com/JuliaRegistries/General/pull/109685 for details. 

This hotfix removes `ConstructionBase` from the dependencies. It shall go directly to main, and will be backported to dev afterwards. 

