### PR TITLE
Hotfix construction base

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,8 @@ stages:
   script:
     - apt update && apt install -y git
     - git clone --depth 1 -b dev https://github.com/QEDjl-project/QED.jl.git /QEDjl
+    - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/QEDjl-project/registry.git"));'
+    - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"));'
     - >
       if [[ $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_BRANCH == "dev" || $CI_COMMIT_REF_NAME == "dev" ]]; then
         # set name of the commit message from CI_COMMIT_MESSAGE to NO_MESSAGE, that the script does not read accidentally custom packages from the commit message of a merge commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 0.2.1
+
+This is a hotfix which adds `ConstructionBase` to the dependencies and the respective
+tests. See https://github.com/QEDjl-project/QEDbase.jl/pull/84 for details.
+
+No further breaking or non-breaking changes.
+
 ## Version 0.2.0
 
 [diff since 0.1.6](https://github.com/QEDjl-project/QEDbase.jl/compare/release-0.1.6...release-0.2.0)

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ version = "0.2.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PhysicalConstants = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
@@ -26,11 +27,13 @@ PhysicalConstants = "0.2.1"
 SimpleTraits = "0.9.4"
 StaticArrays = "1.2.13"
 julia = "1.6"
+ConstructionBase = "1"
 
 [extras]
+QEDcore = "35dc0263-cb5f-4c33-a114-1d7f54ab753e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["SafeTestsets", "Test", "Suppressor"]
+test = ["SafeTestsets", "Test", "Suppressor", "QEDcore"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ authors = [
     "Tom Jungnickel",
     "Anton Reinhard",
 ]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/QEDbase.jl
+++ b/src/QEDbase.jl
@@ -86,7 +86,7 @@ using DocStringExtensions
 
 using SimpleTraits
 using ArgCheck
-#using ConstructionBase
+using ConstructionBase
 
 include("errors.jl")
 include("utils.jl")

--- a/test/core_compat/README.md
+++ b/test/core_compat/README.md
@@ -1,0 +1,7 @@
+# Compatibility tests with `QEDcore`
+
+These tests check if the interfaces in `QEDbase` work correctly with the current
+implementations in `QEDcore`.
+
+This is just a temporary solution and should be removed if the integration tests in
+`QEDcore` are established.

--- a/test/core_compat/four_momentum.jl
+++ b/test/core_compat/four_momentum.jl
@@ -1,0 +1,224 @@
+using QEDbase
+using QEDcore
+using Random
+
+const ATOL = 1e-15
+
+@testset "FourMomentum getter" for MomentumType in [SFourMomentum, MFourMomentum]
+    rng = MersenneTwister(12345)
+    x, y, z = rand(rng, 3)
+    mass = rand(rng)
+    E = sqrt(x^2 + y^2 + z^2 + mass^2)
+    mom_onshell = MomentumType(E, x, y, z)
+    mom_zero = MomentumType(0.0, 0.0, 0.0, 0.0)
+    mom_offshell = MomentumType(0.0, 0.0, 0.0, mass)
+
+    @testset "magnitude consistence" for mom in [mom_onshell, mom_offshell, mom_zero]
+        @test QEDbase.getMagnitude2(mom) == QEDbase.getMag2(mom)
+        @test QEDbase.getMagnitude(mom) == QEDbase.getMag(mom)
+        @test isapprox(QEDbase.getMagnitude(mom), sqrt(QEDbase.getMagnitude2(mom)))
+    end
+
+    @testset "magnitude values" begin
+        @test isapprox(QEDbase.getMagnitude2(mom_onshell), x^2 + y^2 + z^2)
+        @test isapprox(QEDbase.getMagnitude(mom_onshell), sqrt(x^2 + y^2 + z^2))
+    end
+
+    @testset "mass consistence" for mom_on in [mom_onshell, mom_zero]
+        @test QEDbase.getInvariantMass2(mom_on) == QEDbase.getMass2(mom_on)
+        @test QEDbase.getInvariantMass(mom_on) == QEDbase.getMass(mom_on)
+        @test isapprox(
+            QEDbase.getInvariantMass(mom_on), sqrt(QEDbase.getInvariantMass2(mom_on))
+        )
+    end
+
+    @testset "mass value" begin
+        @test isapprox(QEDbase.getInvariantMass2(mom_onshell), E^2 - (x^2 + y^2 + z^2))
+        @test isapprox(QEDbase.getInvariantMass(mom_onshell), sqrt(E^2 - (x^2 + y^2 + z^2)))
+
+        @test isapprox(QEDbase.getInvariantMass(mom_onshell), mass)
+        @test isapprox(QEDbase.getInvariantMass(mom_offshell), -mass)
+        @test isapprox(QEDbase.getInvariantMass(mom_zero), 0.0)
+    end
+
+    @testset "momentum components" begin
+        @test QEDbase.getE(mom_onshell) == E
+        @test QEDbase.getEnergy(mom_onshell) == QEDbase.getE(mom_onshell)
+        @test QEDbase.getPx(mom_onshell) == x
+        @test QEDbase.getPy(mom_onshell) == y
+        @test QEDbase.getPz(mom_onshell) == z
+
+        @test isapprox(QEDbase.getBeta(mom_onshell), sqrt(x^2 + y^2 + z^2) / E)
+        @test isapprox(
+            QEDbase.getGamma(mom_onshell), 1 / sqrt(1.0 - QEDbase.getBeta(mom_onshell)^2)
+        )
+
+        @test QEDbase.getE(mom_zero) == 0.0
+        @test QEDbase.getEnergy(mom_zero) == 0.0
+        @test QEDbase.getPx(mom_zero) == 0.0
+        @test QEDbase.getPy(mom_zero) == 0.0
+        @test QEDbase.getPz(mom_zero) == 0.0
+
+        @test isapprox(QEDbase.getBeta(mom_zero), 0.0)
+        @test isapprox(QEDbase.getGamma(mom_zero), 1.0)
+    end
+
+    @testset "transverse coordinates" for mom_on in [mom_onshell, mom_zero]
+        @test QEDbase.getTransverseMomentum2(mom_on) == QEDbase.getPt2(mom_on)
+        @test QEDbase.getTransverseMomentum2(mom_on) == QEDbase.getPerp2(mom_on)
+        @test QEDbase.getTransverseMomentum(mom_on) == QEDbase.getPt(mom_on)
+        @test QEDbase.getTransverseMomentum(mom_on) == QEDbase.getPerp(mom_on)
+
+        @test isapprox(QEDbase.getPt(mom_on), sqrt(QEDbase.getPt2(mom_on)))
+
+        @test QEDbase.getTransverseMass2(mom_on) == QEDbase.getMt2(mom_on)
+        @test QEDbase.getTransverseMass(mom_on) == QEDbase.getMt(mom_on)
+    end
+
+    @testset "transverse coordiantes value" begin
+        @test isapprox(QEDbase.getTransverseMomentum2(mom_onshell), x^2 + y^2)
+        @test isapprox(QEDbase.getTransverseMomentum(mom_onshell), sqrt(x^2 + y^2))
+        @test isapprox(QEDbase.getTransverseMass2(mom_onshell), E^2 - z^2)
+        @test isapprox(QEDbase.getTransverseMass(mom_onshell), sqrt(E^2 - z^2))
+        @test isapprox(QEDbase.getMt(mom_offshell), -mass)
+        @test isapprox(QEDbase.getRapidity(mom_onshell), 0.5 * log((E + z) / (E - z)))
+
+        @test isapprox(QEDbase.getTransverseMomentum2(mom_zero), 0.0)
+        @test isapprox(QEDbase.getTransverseMomentum(mom_zero), 0.0)
+        @test isapprox(QEDbase.getTransverseMass2(mom_zero), 0.0)
+        @test isapprox(QEDbase.getTransverseMass(mom_zero), 0.0)
+        @test isapprox(QEDbase.getMt(mom_zero), 0.0)
+    end
+
+    @testset "spherical coordiantes consistence" for mom_on in [mom_onshell, mom_zero]
+        @test QEDbase.getRho2(mom_on) == QEDbase.getMagnitude2(mom_on)
+        @test QEDbase.getRho(mom_on) == QEDbase.getMagnitude(mom_on)
+
+        @test isapprox(QEDbase.getCosTheta(mom_on), cos(QEDbase.getTheta(mom_on)))
+        @test isapprox(QEDbase.getCosPhi(mom_on), cos(QEDbase.getPhi(mom_on)))
+        @test isapprox(QEDbase.getSinPhi(mom_on), sin(QEDbase.getPhi(mom_on)))
+    end
+
+    @testset "spherical coordiantes values" begin
+        @test isapprox(QEDbase.getTheta(mom_onshell), atan(QEDbase.getPt(mom_onshell), z))
+        @test isapprox(QEDbase.getTheta(mom_zero), 0.0)
+
+        @test isapprox(QEDbase.getPhi(mom_onshell), atan(y, x))
+        @test isapprox(QEDbase.getPhi(mom_zero), 0.0)
+    end
+
+    @testset "light-cone coordiantes" begin
+        @test isapprox(QEDbase.getPlus(mom_onshell), 0.5 * (E + z))
+        @test isapprox(QEDbase.getMinus(mom_onshell), 0.5 * (E - z))
+
+        @test isapprox(QEDbase.getPlus(mom_zero), 0.0)
+        @test isapprox(QEDbase.getMinus(mom_zero), 0.0)
+    end
+end # FourMomentum getter
+
+function test_get_set(rng, setter, getter; value=rand(rng))
+    x, y, z = rand(rng, 3)
+    mass = rand(rng)
+    E = sqrt(x^2 + y^2 + z^2 + mass^2)
+    mom = MFourMomentum(E, x, y, z)
+    setter(mom, value)
+    return isapprox(getter(mom), value)
+end
+
+@testset "FourMomentum setter" begin
+    rng = MersenneTwister(123456)
+
+    @testset "Momentum components" begin
+        @test test_get_set(rng, QEDbase.setE!, QEDbase.getE)
+        @test test_get_set(rng, QEDbase.setEnergy!, QEDbase.getE)
+        @test test_get_set(rng, QEDbase.setPx!, QEDbase.getPx)
+        @test test_get_set(rng, QEDbase.setPy!, QEDbase.getPy)
+        @test test_get_set(rng, QEDbase.setPz!, QEDbase.getPz)
+    end
+
+    @testset "spherical coordiantes" begin
+        @test test_get_set(rng, QEDbase.setTheta!, QEDbase.getTheta)
+        @test test_get_set(rng, QEDbase.setTheta!, QEDbase.getTheta, value=0.0)
+        @test test_get_set(rng, QEDbase.setCosTheta!, QEDbase.getCosTheta)
+        @test test_get_set(rng, QEDbase.setCosTheta!, QEDbase.getCosTheta, value=1.0)
+        @test test_get_set(rng, QEDbase.setPhi!, QEDbase.getPhi)
+        @test test_get_set(rng, QEDbase.setPhi!, QEDbase.getPhi, value=0.0)
+        @test test_get_set(rng, QEDbase.setRho!, QEDbase.getRho)
+        @test test_get_set(rng, QEDbase.setRho!, QEDbase.getRho, value=0.0)
+    end
+
+    @testset "light-cone coordiantes" begin
+        @test test_get_set(rng, QEDbase.setPlus!, QEDbase.getPlus)
+        @test test_get_set(rng, QEDbase.setPlus!, QEDbase.getPlus, value=0.0)
+        @test test_get_set(rng, QEDbase.setMinus!, QEDbase.getMinus)
+        @test test_get_set(rng, QEDbase.setMinus!, QEDbase.getMinus, value=0.0)
+    end
+
+    @testset "transverse coordinates" begin
+        @test test_get_set(
+            rng, QEDbase.setTransverseMomentum!, QEDbase.getTransverseMomentum
+        )
+        @test test_get_set(
+            rng, QEDbase.setTransverseMomentum!, QEDbase.getTransverseMomentum, value=0.0
+        )
+        @test test_get_set(rng, QEDbase.setPerp!, QEDbase.getTransverseMomentum)
+        @test test_get_set(rng, QEDbase.setPt!, QEDbase.getTransverseMomentum)
+        @test test_get_set(rng, QEDbase.setTransverseMass!, QEDbase.getTransverseMass)
+        @test test_get_set(
+            rng, QEDbase.setTransverseMass!, QEDbase.getTransverseMass, value=0.0
+        )
+        @test test_get_set(rng, QEDbase.setMt!, QEDbase.getTransverseMass)
+        @test test_get_set(rng, QEDbase.setRapidity!, QEDbase.getRapidity)
+        @test test_get_set(rng, QEDbase.setRapidity!, QEDbase.getRapidity, value=0.0)
+    end
+end # FourMomentum setter
+
+const SCALE = 10.0 .^ [-9, 0, 5]
+const M_MASSIVE = 1.0
+const M_MASSLESS = 0.0
+
+const M_ABSERR = 0.01
+const M_RELERR = 0.0001
+
+@testset "isonshell" begin
+    rng = MersenneTwister(42)
+    x_base, y_base, z_base = rand(rng, 3)
+
+    @testset "correct onshell" begin
+        @testset "($x_scale, $y_scale, $z_scale)" for (x_scale, y_scale, z_scale) in
+                                                      Iterators.product(SCALE, SCALE, SCALE)
+            x, y, z = x_base * x_scale, y_base * y_scale, z_base * z_scale
+            E_massless = sqrt(x^2 + y^2 + z^2 + M_MASSLESS^2)
+            E_massive = sqrt(x^2 + y^2 + z^2 + M_MASSIVE^2)
+            mom_massless = SFourMomentum(E_massless, x, y, z)
+            mom_massive = SFourMomentum(E_massive, x, y, z)
+            @test QEDbase.isonshell(mom_massless, M_MASSLESS)
+            @test QEDbase.isonshell(mom_massive, M_MASSIVE)
+
+            @test QEDbase.assert_onshell(mom_massless, M_MASSLESS) == nothing
+            @test QEDbase.assert_onshell(mom_massive, M_MASSIVE) == nothing
+        end
+    end
+
+    @testset "correct not onshell" begin
+        @testset "$x_scale, $y_scale, $z_scale" for (x_scale, y_scale, z_scale) in
+                                                    Iterators.product(SCALE, SCALE, SCALE)
+            x, y, z = x_base * x_scale, y_base * y_scale, z_base * z_scale
+            m_err = min(M_ABSERR, M_RELERR * sum([x, y, z]) / 3.0) # mass error is M_RELERR of the mean of the components
+            # but has at most the value M_ABSERR
+
+            E_massless = sqrt(x^2 + y^2 + z^2 + (M_MASSLESS + m_err)^2)
+            E_massive = sqrt(x^2 + y^2 + z^2 + (M_MASSIVE + m_err)^2)
+            mom_massless = SFourMomentum(E_massless, x, y, z)
+            mom_massive = SFourMomentum(E_massive, x, y, z)
+
+            @test !QEDbase.isonshell(mom_massless, M_MASSLESS)
+            @test !QEDbase.isonshell(mom_massive, M_MASSIVE)
+
+            @test_throws QEDbase.OnshellError QEDbase.assert_onshell(
+                mom_massless, M_MASSLESS
+            )
+            @test_throws QEDbase.OnshellError QEDbase.assert_onshell(mom_massive, M_MASSIVE)
+        end
+    end
+end

--- a/test/core_compat/lorentz_vector.jl
+++ b/test/core_compat/lorentz_vector.jl
@@ -1,0 +1,99 @@
+using QEDbase
+using QEDcore
+using StaticArrays
+
+unary_methods = [-, +]
+
+@testset "$LorentzVectorType" for LorentzVectorType in [SLorentzVector, MLorentzVector]
+    @testset "General Properties" begin
+        LV = LorentzVectorType(rand(Float64, 4))
+
+        @test size(LV) == (4,)
+        @test length(LV) == 4
+        @test eltype(LV) == Float64
+
+        @test @inferred(LorentzVectorType(1, 2, 3, 4)) == LorentzVectorType([1, 2, 3, 4])
+
+        @test LorentzVectorType(1, 2, 3, 4) == LorentzVectorType(SVector{4}(1, 2, 3, 4))
+
+        M = rand(Float64, 4, 4)
+        LV_mat = LorentzVectorType(M, M, M, M)
+
+        @test size(LV_mat) == (4,)
+        @test length(LV_mat) == 4
+        @test eltype(LV_mat) == typeof(M)
+
+        @test_throws DimensionMismatch(
+            "No precise constructor for $(LorentzVectorType) found. Length of input was 2."
+        ) LorentzVectorType(1, 2)
+
+        @test LV.t == LV[1] == QEDbase.getT(LV)
+        @test LV.x == LV[2] == QEDbase.getX(LV)
+        @test LV.y == LV[3] == QEDbase.getY(LV)
+        @test LV.z == LV[4] == QEDbase.getZ(LV)
+    end # General Properties
+
+    @testset "Arithmetics" begin
+        num = 2.0
+        LV1 = LorentzVectorType(1, 2, 3, 4)
+        LV2 = LorentzVectorType(4, 3, 2, 1)
+
+        @test @inferred(LV1 + LV2) == LorentzVectorType(5, 5, 5, 5)
+        @test @inferred(LV1 - LV2) == LorentzVectorType(-3, -1, 1, 3)
+
+        @test LV1 * LV2 == -12.0
+
+        @test @inferred(num * LV1) == LorentzVectorType(2, 4, 6, 8)
+        @test @inferred(LV1 * num) == LorentzVectorType(2, 4, 6, 8)
+        @test @inferred(LV1 / num) == LorentzVectorType(0.5, 1.0, 1.5, 2.0)
+
+        num_cmplx = 1.0 + 1.0im
+
+        #maybe use @inferred for type stability check
+        @test typeof(num_cmplx * LV1) === LorentzVectorType{ComplexF64} # type casting
+        @test eltype(num_cmplx * LV1) === ComplexF64 # type casting
+        @test typeof(LV1 * num_cmplx) === LorentzVectorType{ComplexF64} # type casting
+        @test eltype(LV1 * num_cmplx) === ComplexF64 # type casting
+        @test typeof(LV1 / num_cmplx) === LorentzVectorType{ComplexF64} # type casting
+        @test eltype(LV1 / num_cmplx) === ComplexF64 # type casting
+
+        LV = LorentzVectorType(rand(4))
+        for ops in unary_methods
+            res = ops(LV)
+            @test typeof(res) == typeof(LV)
+            @test SArray(res) == ops(SArray(LV))
+        end
+    end # Arithmetics
+
+    @testset "interface dirac tensor" begin
+        DM_eye = one(DiracMatrix)
+        BS = BiSpinor(1, 2, 3, 4)
+        aBS = AdjointBiSpinor(1, 2, 3, 4)
+
+        LV_mat = LorentzVectorType(DM_eye, DM_eye, DM_eye, DM_eye)
+        LV_BS = LorentzVectorType(BS, BS, BS, BS)
+        LV_aBS = LorentzVectorType(aBS, aBS, aBS, aBS)
+
+        @test @inferred(LV_mat * BS) == LV_BS
+        @test @inferred(aBS * LV_mat) == LV_aBS
+        @test @inferred(LV_aBS * LV_BS) == -60.0 + 0.0im
+    end #interface dirac tensor
+
+    @testset "utility functions" begin
+        LV = LorentzVectorType(4, 3, 2, 1)
+
+        @test isapprox(@inferred(QEDbase.getMagnitude(LV)), sqrt(14))
+    end # utility functions
+end # LorentzVectorType
+
+@testset "different LorentzVectorTypes" begin
+    @testset "Artihmetics" begin
+        LV1 = SLorentzVector(1, 2, 3, 4)
+        LV2 = MLorentzVector(4, 3, 2, 1)
+
+        @test @inferred(LV1 + LV2) === SLorentzVector(5, 5, 5, 5)
+        @test @inferred(LV1 - LV2) === SLorentzVector(-3, -1, 1, 3)
+
+        @test LV1 * LV2 == -12.0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ begin
     @time @safetestset "particles" begin
         include("particle_properties.jl")
     end
-    
+
     @time @safetestset "QEDcore: Lorentz vector" begin
         include("core_compat/lorentz_vector.jl")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,4 +15,12 @@ begin
     @time @safetestset "particles" begin
         include("particle_properties.jl")
     end
+    
+    @time @safetestset "QEDcore: Lorentz vector" begin
+        include("core_compat/lorentz_vector.jl")
+    end
+
+    @time @safetestset "QEDcore: FourMomentum" begin
+        include("core_compat/four_momentum.jl")
+    end
 end


### PR DESCRIPTION
Add `ConstructionBase` with the correct `[compat]` entry, and test for compatibility with `QEDcore`. 


This is a hotfix, because the current release is broken. Therefore, this goes directly into `main` and is immediately released as version 0.2.1.  

This change is rebased and merged to `dev` afterward. 
