### PR TITLE
Add cross section and probability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "QEDbase"
 uuid = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
+<<<<<<< HEAD
 authors = [
     "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
     "Simeon Ehrig",
@@ -8,6 +9,10 @@ authors = [
     "Anton Reinhard",
 ]
 version = "0.2.1"
+=======
+authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
+version = "0.2.0"
+>>>>>>> 954c82e (added cross section and tests)
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,5 @@
 name = "QEDbase"
 uuid = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
-<<<<<<< HEAD
 authors = [
     "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
     "Simeon Ehrig",
@@ -9,10 +8,6 @@ authors = [
     "Anton Reinhard",
 ]
 version = "0.2.1"
-=======
-authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
-version = "0.2.0"
->>>>>>> 954c82e (added cross section and tests)
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -27,12 +22,12 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 ArgCheck = "2.3.0"
+ConstructionBase = "1"
 DocStringExtensions = "0.8.5, 0.9"
 PhysicalConstants = "0.2.1"
 SimpleTraits = "0.9.4"
 StaticArrays = "1.2.13"
 julia = "1.6"
-ConstructionBase = "1"
 
 [extras]
 QEDcore = "35dc0263-cb5f-4c33-a114-1d7f54ab753e"

--- a/src/QEDbase.jl
+++ b/src/QEDbase.jl
@@ -115,6 +115,9 @@ include("interfaces/particle_stateful.jl")
 include("interfaces/phase_space_point.jl")
 include("interfaces/setup.jl")
 
-include("total_cross_section.jl")
+include("cross_section/diff_probability.jl")
+include("cross_section/diff_cross_section.jl")
+include("cross_section/total_probability.jl")
+include("cross_section/total_cross_section.jl")
 
 end #QEDbase

--- a/src/cross_section/diff_cross_section.jl
+++ b/src/cross_section/diff_cross_section.jl
@@ -23,7 +23,9 @@ If the given phase spaces are physical, return differential cross section evalua
 """
 function differential_cross_section(phase_space_point::AbstractPhaseSpacePoint)
     if !_is_in_phasespace(phase_space_point)
-        return zero(eltype(_momentum_type(phase_space_point)))
+        # TODO: use the correct type here, i.e. implement a function `eltype` for psp or 
+        # make `momentum_type` an interface function. 
+        return zero(Float64)
     end
 
     return unsafe_differential_cross_section(phase_space_point)

--- a/src/cross_section/diff_cross_section.jl
+++ b/src/cross_section/diff_cross_section.jl
@@ -1,0 +1,30 @@
+########################
+# differential and total cross sections.
+#
+# This file contains default implementations for differential 
+# cross sections based on the scattering process interface
+########################
+
+"""
+    unsafe_differential_cross_section(phase_space_point::AbstractPhaseSpacePoint)
+
+Return the differential cross section evaluated on a phase space point without checking if the given phase space is physical.
+"""
+function unsafe_differential_cross_section(phase_space_point::AbstractPhaseSpacePoint)
+    I = 1 / (4 * _incident_flux(phase_space_point))
+
+    return I * unsafe_differential_probability(phase_space_point)
+end
+
+"""
+    differential_cross_section(phase_space_point::PhaseSpacePoint)
+
+If the given phase spaces are physical, return differential cross section evaluated on a phase space point. Zero otherwise.
+"""
+function differential_cross_section(phase_space_point::AbstractPhaseSpacePoint)
+    if !_is_in_phasespace(phase_space_point)
+        return zero(eltype(_momentum_type(phase_space_point)))
+    end
+
+    return unsafe_differential_cross_section(phase_space_point)
+end

--- a/src/cross_section/diff_probability.jl
+++ b/src/cross_section/diff_probability.jl
@@ -1,0 +1,42 @@
+############
+# scattering probabilities
+#
+# This file contains implementations of the scattering probability based on the
+# process interface with and without input validation and/or phase space
+# constraint.
+############
+
+# convenience function
+# can be overloaded if an analytical version is known
+function _matrix_element_square(psp::AbstractPhaseSpacePoint)
+    mat_el = _matrix_element(psp)
+    return abs2.(mat_el)
+end
+
+"""
+    unsafe_differential_probability(phase_space_point::AbstractPhaseSpacePoint)
+
+Return differential probability evaluated on a phase space point without checking if the given phase space(s) are physical.
+"""
+function unsafe_differential_probability(psp::AbstractPhaseSpacePoint)
+    matrix_elements_sq = _matrix_element_square(psp)
+
+    normalization = _averaging_norm(psp.proc)
+
+    ps_fac = _phase_space_factor(psp)
+
+    return normalization * sum(matrix_elements_sq) * ps_fac
+end
+
+"""
+    differential_probability(phase_space_point::AbstractPhaseSpacePoint)
+
+If the given phase spaces are physical, return differential probability evaluated on a phase space point. Zero otherwise.
+"""
+function differential_probability(phase_space_point::AbstractPhaseSpacePoint)
+    if !_is_in_phasespace(phase_space_point)
+        return zero(eltype(momentum(phase_space_point, Incoming(), 1)))
+    end
+
+    return unsafe_differential_probability(phase_space_point)
+end

--- a/src/cross_section/total_cross_section.jl
+++ b/src/cross_section/total_cross_section.jl
@@ -4,11 +4,11 @@
 ############
 
 """
-    total_cross_section(in_psp::InPhaseSpacePoint)
+    total_cross_section(in_psp::AbstractInPhaseSpacePoint)
 
-Return the total cross section for a given [`InPhaseSpacePoint`](@ref).
+Return the total cross section for a given [`AbstractInPhaseSpacePoint`](@ref).
 """
-function total_cross_section(in_psp::InPhaseSpacePoint)
+function total_cross_section(in_psp::AbstractInPhaseSpacePoint)
     I = 1 / (4 * _incident_flux(in_psp))
     return I * _total_probability(in_psp)
 end

--- a/src/cross_section/total_cross_section.jl
+++ b/src/cross_section/total_cross_section.jl
@@ -1,0 +1,14 @@
+
+############
+# Total cross sections
+############
+
+"""
+    total_cross_section(in_psp::InPhaseSpacePoint)
+
+Return the total cross section for a given [`InPhaseSpacePoint`](@ref).
+"""
+function total_cross_section(in_psp::InPhaseSpacePoint)
+    I = 1 / (4 * _incident_flux(in_psp))
+    return I * _total_probability(in_psp)
+end

--- a/src/cross_section/total_probability.jl
+++ b/src/cross_section/total_probability.jl
@@ -1,0 +1,12 @@
+###########
+# Total probability
+###########
+
+"""
+    total_probability(in_psp::AbstractInPhaseSpacePoint)
+
+Return the total probability of a given [`AbstractInPhaseSpacePoint`](@ref).
+"""
+function total_probability(in_psp::AbstractInPhaseSpacePoint)
+    return _total_probability(in_psp)
+end

--- a/test/cross_sections.jl
+++ b/test/cross_sections.jl
@@ -1,7 +1,6 @@
-# TODO: rebase after latest change in QEDbase is backported
 using Random
-using QEDcore
 using QEDbase
+using QEDcore
 
 RNG = MersenneTwister(137137)
 ATOL = 0.0
@@ -72,8 +71,8 @@ TESTPSDEF = TestImplementation.TestPhasespaceDef()
             )
 
             groundtruth = TestImplementation._groundtruth_total_cross_section(p_in_phys)
-            totCS_on_moms = QEDprocesses.total_cross_section(IN_PS_POINT)
-            totCS_on_coords = QEDprocesses.total_cross_section(IN_PS_POINT_COORDS)
+            totCS_on_moms = total_cross_section(IN_PS_POINT)
+            totCS_on_coords = total_cross_section(IN_PS_POINT_COORDS)
 
             @test isapprox(totCS_on_moms, groundtruth, atol=ATOL, rtol=RTOL)
             @test isapprox(totCS_on_coords, groundtruth, atol=ATOL, rtol=RTOL)
@@ -114,8 +113,8 @@ TESTPSDEF = TestImplementation.TestPhasespaceDef()
             )
 
             groundtruth = TestImplementation._groundtruth_total_probability(p_in_phys)
-            totCS_on_moms = total_probability(IN_PS_POINT)
-            totCS_on_coords = total_probability(IN_PS_POINT_COORDS)
+            totCS_on_moms = TestImplementation.total_probability(IN_PS_POINT)
+            totCS_on_coords = TestImplementation.total_probability(IN_PS_POINT_COORDS)
 
             @test isapprox(totCS_on_moms, groundtruth, atol=ATOL, rtol=RTOL)
             @test isapprox(totCS_on_coords, groundtruth, atol=ATOL, rtol=RTOL)

--- a/test/cross_sections.jl
+++ b/test/cross_sections.jl
@@ -1,0 +1,124 @@
+# TODO: rebase after latest change in QEDbase is backported
+using Random
+using QEDcore
+using QEDbase
+
+RNG = MersenneTwister(137137)
+ATOL = 0.0
+RTOL = sqrt(eps())
+
+include("test_implementation/TestImplementation.jl")
+TESTMODEL = TestImplementation.TestModel()
+TESTPSDEF = TestImplementation.TestPhasespaceDef()
+
+@testset "($N_INCOMING,$N_OUTGOING)" for (N_INCOMING, N_OUTGOING) in Iterators.product(
+    (1, rand(RNG, 2:8)), (1, rand(RNG, 2:8))
+)
+    INCOMING_PARTICLES = Tuple(rand(RNG, TestImplementation.PARTICLE_SET, N_INCOMING))
+    OUTGOING_PARTICLES = Tuple(rand(RNG, TestImplementation.PARTICLE_SET, N_OUTGOING))
+
+    TESTPROC = TestImplementation.TestProcess(INCOMING_PARTICLES, OUTGOING_PARTICLES)
+
+    # single ps points
+    p_in_phys = TestImplementation._rand_momenta(RNG, N_INCOMING)
+    p_in_phys_invalid = TestImplementation._rand_momenta(RNG, N_INCOMING + 1)
+    p_in_unphys = TestImplementation._rand_in_momenta_failing(RNG, N_INCOMING)
+
+    p_out_phys = TestImplementation._rand_momenta(RNG, N_OUTGOING)
+    p_out_unphys = TestImplementation._rand_out_momenta_failing(RNG, N_OUTGOING)
+
+    p_in_all = (p_in_phys, p_in_unphys)
+
+    p_out_all = (p_out_phys, p_out_unphys)
+
+    # all combinations
+    p_combs = Iterators.product(p_in_all, p_out_all)
+
+    @testset "differential cross section" begin
+        @testset "unsafe compute" begin
+            PS_POINT = PhaseSpacePoint(
+                TESTPROC, TESTMODEL, TESTPSDEF, p_in_phys, p_out_phys
+            )
+
+            diffCS_on_psp = unsafe_differential_cross_section(PS_POINT)
+            groundtruth = TestImplementation._groundtruth_unsafe_diffCS(
+                TESTPROC, p_in_phys, p_out_phys
+            )
+
+            @test isapprox(diffCS_on_psp, groundtruth, atol=ATOL, rtol=RTOL)
+        end
+
+        @testset "safe compute" begin
+            for (P_IN, P_OUT) in p_combs
+                PS_POINT = PhaseSpacePoint(TESTPROC, TESTMODEL, TESTPSDEF, P_IN, P_OUT)
+
+                diffCS_on_psp = differential_cross_section(PS_POINT)
+                groundtruth = TestImplementation._groundtruth_safe_diffCS(
+                    TESTPROC, P_IN, P_OUT
+                )
+
+                @test isapprox(diffCS_on_psp, groundtruth, atol=ATOL, rtol=RTOL)
+            end
+        end
+    end
+
+    @testset "total cross section" begin
+        @testset "compute" begin
+            COORDS_IN = TestImplementation.flat_components(p_in_phys)
+
+            IN_PS_POINT = InPhaseSpacePoint(TESTPROC, TESTMODEL, TESTPSDEF, p_in_phys)
+            IN_PS_POINT_COORDS = InPhaseSpacePoint(
+                TESTPROC, TESTMODEL, TESTPSDEF, COORDS_IN
+            )
+
+            groundtruth = TestImplementation._groundtruth_total_cross_section(p_in_phys)
+            totCS_on_moms = QEDprocesses.total_cross_section(IN_PS_POINT)
+            totCS_on_coords = QEDprocesses.total_cross_section(IN_PS_POINT_COORDS)
+
+            @test isapprox(totCS_on_moms, groundtruth, atol=ATOL, rtol=RTOL)
+            @test isapprox(totCS_on_coords, groundtruth, atol=ATOL, rtol=RTOL)
+        end
+    end
+
+    @testset "differential probability" begin
+        @testset "unsafe compute" begin
+            PS_POINT = PhaseSpacePoint(
+                TESTPROC, TESTMODEL, TESTPSDEF, p_in_phys, p_out_phys
+            )
+            prop_on_psp = unsafe_differential_probability(PS_POINT)
+            groundtruth = TestImplementation._groundtruth_unsafe_probability(
+                TESTPROC, p_in_phys, p_out_phys
+            )
+            @test isapprox(prop_on_psp, groundtruth, atol=ATOL, rtol=RTOL)
+        end
+
+        @testset "safe compute" begin
+            for (P_IN, P_OUT) in p_combs
+                PS_POINT = PhaseSpacePoint(TESTPROC, TESTMODEL, TESTPSDEF, P_IN, P_OUT)
+                prop_on_psp = differential_probability(PS_POINT)
+                groundtruth = TestImplementation._groundtruth_safe_probability(
+                    TESTPROC, P_IN, P_OUT
+                )
+                @test isapprox(prop_on_psp, groundtruth, atol=ATOL, rtol=RTOL)
+            end
+        end
+    end
+
+    @testset "total probability" begin
+        @testset "compute" begin
+            COORDS_IN = TestImplementation.flat_components(p_in_phys)
+
+            IN_PS_POINT = InPhaseSpacePoint(TESTPROC, TESTMODEL, TESTPSDEF, p_in_phys)
+            IN_PS_POINT_COORDS = InPhaseSpacePoint(
+                TESTPROC, TESTMODEL, TESTPSDEF, COORDS_IN
+            )
+
+            groundtruth = TestImplementation._groundtruth_total_probability(p_in_phys)
+            totCS_on_moms = total_probability(IN_PS_POINT)
+            totCS_on_coords = total_probability(IN_PS_POINT_COORDS)
+
+            @test isapprox(totCS_on_moms, groundtruth, atol=ATOL, rtol=RTOL)
+            @test isapprox(totCS_on_coords, groundtruth, atol=ATOL, rtol=RTOL)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,4 +23,8 @@ begin
     @time @safetestset "QEDcore: FourMomentum" begin
         include("core_compat/four_momentum.jl")
     end
+    
+    @time @safetestset "cross sections" begin
+        include("cross_sections.jl")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ begin
     @time @safetestset "QEDcore: FourMomentum" begin
         include("core_compat/four_momentum.jl")
     end
-    
+
     @time @safetestset "cross sections" begin
         include("cross_sections.jl")
     end

--- a/test/test_implementation/TestImplementation.jl
+++ b/test/test_implementation/TestImplementation.jl
@@ -1,0 +1,40 @@
+"""
+This module provides a full implementation of the model and process interface. Its purpose is only for testing and it does not reflect any 
+real-world physics. 
+
+The module exports:
+
+```
+TestParticle1               # set of test particles without properties
+TestParticle2
+TestParticle3
+TestParticle4
+TestModel                   # dummy compute model
+TestModel_FAIL              # failing compute model
+TestProcess                 # dummy scattering process 
+TestProcess_FAIL            # failing scattering process 
+TestPhasespaceDef           # dummy phase space definition
+TestPhasespaceDef_FAIL      # failing phase space definition
+```
+The respective groundtruth implementations for the interface functions are stored in `groundtruths.jl`
+"""
+module TestImplementation
+
+export TestParticle1, TestParticle2, TestParticle3, TestParticle4, PARTICLE_SET
+export TestModel, TestModel_FAIL
+export TestProcess, TestProcess_FAIL
+export TestPhasespaceDef, TestPhasespaceDef_FAIL
+
+using Random
+using QEDbase: QEDbase
+using QEDcore
+using QEDprocesses
+using StaticArrays
+
+include("groundtruths.jl")
+include("test_model.jl")
+include("test_process.jl")
+include("random_momenta.jl")
+include("utils.jl")
+
+end

--- a/test/test_implementation/TestImplementation.jl
+++ b/test/test_implementation/TestImplementation.jl
@@ -26,9 +26,8 @@ export TestProcess, TestProcess_FAIL
 export TestPhasespaceDef, TestPhasespaceDef_FAIL
 
 using Random
-using QEDbase: QEDbase
+using QEDbase
 using QEDcore
-using QEDprocesses
 using StaticArrays
 
 include("groundtruths.jl")

--- a/test/test_implementation/groundtruths.jl
+++ b/test/test_implementation/groundtruths.jl
@@ -1,0 +1,265 @@
+import QEDbase.AbstractFourMomentum
+
+"""
+    _groundtruth_incident_flux(in_ps)
+
+Test implementation of the incident flux. Return the Minkowski square of the sum of the incoming momenta:
+
+```math
+\\begin{align}
+I = \\left(\\sum p_i\\right)^2,
+\\end{align}
+```
+where \$p_i\\in\\mathrm{ps_in}\$. 
+"""
+function _groundtruth_incident_flux(in_ps)
+    s = sum(in_ps)
+    return s * s
+end
+
+"""
+    _groundtruth_matrix_element(in_ps, out_ps)
+
+Test implementation for a matrix elements. Returns a list of three complex numbers without any physical meaning. 
+"""
+function _groundtruth_matrix_element(in_ps, out_ps)
+    s_in = sum(in_ps)
+    s_out = sum(out_ps)
+    res = s_in * s_in + 1im * (s_out * s_out)
+    return (res, 2 * res, 3 * res)
+end
+
+"""
+    _groundtruth_averaging_norm(proc)
+
+Test implementation of the averaging norm. Returns the inverse of the sum of all external particles of the passed process.
+"""
+function _groundtruth_averaging_norm(proc)
+    return 1.0 / (number_incoming_particles(proc) + number_outgoing_particles(proc))
+end
+
+"""
+    _groundtruth_is_in_phasespace(in_ps, out_ps)
+
+Test implementation of the phase space check. Return `false` if either the momentum of the first incoming particle is exactly `zero(SFourMomentum)`, or if the momentum of the last outgoing momentum is exactly `ones(SFourMomentum)`. Otherwise, return true.
+"""
+function _groundtruth_is_in_phasespace(in_ps, out_ps)
+    if in_ps[1] == SFourMomentum(zeros(4))
+        return false
+    end
+    if out_ps[end] == ones(SFourMomentum)
+        return false
+    end
+    return true
+end
+
+"""
+    _groundtruth_phase_space_factor(in_ps, out_ps)
+
+Test implementation of the phase space factor. Return the inverse of the product of the energies of all external particles.
+"""
+function _groundtruth_phase_space_factor(in_ps, out_ps)
+    en_in = QEDbase.getE.(in_ps)
+    en_out = QEDbase.getE.(out_ps)
+    return 1 / (prod(en_in) * prod(en_out))
+end
+
+function _groundtruth_generate_momenta(ps_coords)
+    moms = _furl_moms(ps_coords)
+    return moms
+end
+"""
+    _groundtruth_unsafe_probability(proc, in_ps, out_ps)
+
+Test implementation of the unsafe differential probability. Uses the test implementations of `_groundtruth_matrix_element`,`_groundtruth_averaging_norm` and `_groundtruth_phase_space_factor`.
+"""
+function _groundtruth_unsafe_probability(proc, in_ps, out_ps)
+    mat_el = _groundtruth_matrix_element(in_ps, out_ps)
+    mat_el_sq = abs2.(mat_el)
+    normalization = _groundtruth_averaging_norm(proc)
+    ps_fac = _groundtruth_phase_space_factor(in_ps, out_ps)
+    return sum(mat_el_sq) * ps_fac * normalization
+end
+
+function _groundtruth_unsafe_probability(
+    proc, in_ps::AbstractVector, out_ps::AbstractMatrix
+)
+    res = Vector{Float64}(undef, size(out_ps, 2))
+    for i in 1:size(out_ps, 2)
+        res[i] = _groundtruth_unsafe_probability(proc, in_ps, view(out_ps, :, i))
+    end
+    return res
+end
+
+function _groundtruth_unsafe_probability(
+    proc, in_ps::AbstractMatrix, out_ps::AbstractVector
+)
+    res = Vector{Float64}(undef, size(in_ps, 2))
+    for i in 1:size(in_ps, 2)
+        res[i] = _groundtruth_unsafe_probability(proc, view(in_ps, :, i), out_ps)
+    end
+    return res
+end
+
+function _groundtruth_unsafe_probability(
+    proc, in_ps::AbstractMatrix, out_ps::AbstractMatrix
+)
+    res = Matrix{Float64}(undef, size(in_ps, 2), size(out_ps, 2))
+    for i in 1:size(in_ps, 2)
+        for j in 1:size(out_ps, 2)
+            res[i, j] = _groundtruth_unsafe_probability(
+                proc, view(in_ps, :, i), view(out_ps, :, j)
+            )
+        end
+    end
+    return res
+end
+
+"""
+    _groundtruth_safe_probability(proc, in_ps, out_ps)
+
+Test implementation of the safe differential probability. Uses the test implementations of `_groundtruth_is_in_phasespace` and `_groundtruth_unsafe_probability`.
+"""
+function _groundtruth_safe_probability(proc, in_ps, out_ps)
+    if !_groundtruth_is_in_phasespace(in_ps, out_ps)
+        return zero(Float64)
+    end
+    return _groundtruth_unsafe_probability(proc, in_ps, out_ps)
+end
+
+function _groundtruth_safe_probability(proc, in_ps::AbstractVector, out_ps::AbstractMatrix)
+    res = Vector{Float64}(undef, size(out_ps, 2))
+    for i in 1:size(out_ps, 2)
+        res[i] = _groundtruth_safe_probability(proc, in_ps, view(out_ps, :, i))
+    end
+    return res
+end
+
+function _groundtruth_safe_probability(proc, in_ps::AbstractMatrix, out_ps::AbstractVector)
+    res = Vector{Float64}(undef, size(in_ps, 2))
+    for i in 1:size(in_ps, 2)
+        res[i] = _groundtruth_safe_probability(proc, view(in_ps, :, i), out_ps)
+    end
+    return res
+end
+
+function _groundtruth_safe_probability(proc, in_ps::AbstractMatrix, out_ps::AbstractMatrix)
+    res = Matrix{Float64}(undef, size(in_ps, 2), size(out_ps, 2))
+    for i in 1:size(in_ps, 2)
+        for j in 1:size(out_ps, 2)
+            res[i, j] = _groundtruth_safe_probability(
+                proc, view(in_ps, :, i), view(out_ps, :, j)
+            )
+        end
+    end
+    return res
+end
+
+"""
+    _groundtruth_unsafe_diffCS(proc, in_ps, out_ps)
+
+Test implementation of the unsafe differential cross section. Uses the test implementations of `_groundtruth_incident_flux` and `_groundtruth_unsafe_probability`. 
+"""
+function _groundtruth_unsafe_diffCS(proc, in_ps, out_ps)
+    init_flux = _groundtruth_incident_flux(in_ps)
+    return _groundtruth_unsafe_probability(proc, in_ps, out_ps) / (4 * init_flux)
+end
+
+function _groundtruth_unsafe_diffCS(proc, in_ps::AbstractVector, out_ps::AbstractMatrix)
+    res = Vector{Float64}(undef, size(out_ps, 2))
+    for i in 1:size(out_ps, 2)
+        res[i] = _groundtruth_unsafe_diffCS(proc, in_ps, view(out_ps, :, i))
+    end
+    return res
+end
+
+function _groundtruth_unsafe_diffCS(proc, in_ps::AbstractMatrix, out_ps::AbstractVector)
+    res = Vector{Float64}(undef, size(in_ps, 2))
+    for i in 1:size(in_ps, 2)
+        res[i] = _groundtruth_unsafe_diffCS(proc, view(in_ps, :, i), out_ps)
+    end
+    return res
+end
+
+function _groundtruth_unsafe_diffCS(proc, in_ps::AbstractMatrix, out_ps::AbstractMatrix)
+    res = Matrix{Float64}(undef, size(in_ps, 2), size(out_ps, 2))
+    for i in 1:size(in_ps, 2)
+        for j in 1:size(out_ps, 2)
+            res[i, j] = _groundtruth_unsafe_diffCS(
+                proc, view(in_ps, :, i), view(out_ps, :, j)
+            )
+        end
+    end
+    return res
+end
+
+"""
+    _groundtruth_safe_diffCS(proc, in_ps, out_ps)
+
+Test implementation of the safe differential cross section. Uses the test implementations of `_groundtruth_is_in_phasespace` and `_groundtruth_unsafe_diffCS`. 
+"""
+function _groundtruth_safe_diffCS(proc, in_ps, out_ps)
+    if !_groundtruth_is_in_phasespace(in_ps, out_ps)
+        return zero(Float64)
+    end
+    return _groundtruth_unsafe_diffCS(proc, in_ps, out_ps)
+end
+
+function _groundtruth_safe_diffCS(proc, in_ps::AbstractVector, out_ps::AbstractMatrix)
+    res = Vector{Float64}(undef, size(out_ps, 2))
+    for i in 1:size(out_ps, 2)
+        res[i] = _groundtruth_safe_diffCS(proc, in_ps, view(out_ps, :, i))
+    end
+    return res
+end
+
+function _groundtruth_safe_diffCS(proc, in_ps::AbstractMatrix, out_ps::AbstractVector)
+    res = Vector{Float64}(undef, size(in_ps, 2))
+    for i in 1:size(in_ps, 2)
+        res[i] = _groundtruth_safe_diffCS(proc, view(in_ps, :, i), out_ps)
+    end
+    return res
+end
+
+function _groundtruth_safe_diffCS(proc, in_ps::AbstractMatrix, out_ps::AbstractMatrix)
+    res = Matrix{Float64}(undef, size(in_ps, 2), size(out_ps, 2))
+    for i in 1:size(in_ps, 2)
+        for j in 1:size(out_ps, 2)
+            res[i, j] = _groundtruth_safe_diffCS(
+                proc, view(in_ps, :, i), view(out_ps, :, j)
+            )
+        end
+    end
+    return res
+end
+
+"""
+    _groundtruth_total_probability(in_ps::AbstractVector)
+
+Test implementation of the total cross section. Return the Minkowski square of the sum the momenta of all incoming particles.
+"""
+function _groundtruth_total_probability(
+    in_ps::NTuple{N,T}
+) where {N,T<:AbstractFourMomentum}
+    Ptot = sum(in_ps)
+    return Ptot * Ptot
+end
+
+function _groundtruth_total_probability(
+    in_pss::Vector{NTuple{N,T}}
+) where {N,T<:AbstractFourMomentum}
+    return _groundtruth_total_probability.(in_pss)
+end
+
+function _groundtruth_total_cross_section(
+    in_ps::NTuple{N,T}
+) where {N,T<:AbstractFourMomentum}
+    init_flux = _groundtruth_incident_flux(in_ps)
+    return _groundtruth_total_probability(in_ps) / (4 * init_flux)
+end
+
+function _groundtruth_total_cross_section(
+    in_pss::Vector{NTuple{N,T}}
+) where {N,T<:AbstractFourMomentum}
+    return _groundtruth_total_cross_section.(in_psps)
+end

--- a/test/test_implementation/groundtruths.jl
+++ b/test/test_implementation/groundtruths.jl
@@ -1,5 +1,3 @@
-import QEDbase.AbstractFourMomentum
-
 """
     _groundtruth_incident_flux(in_ps)
 

--- a/test/test_implementation/random_momenta.jl
+++ b/test/test_implementation/random_momenta.jl
@@ -1,0 +1,83 @@
+
+"""
+Return a tuple of random four momenta, i.e. a random phase space point.
+"""
+function _rand_momenta(rng::AbstractRNG, n)
+    return NTuple{n,SFourMomentum}(SFourMomentum(rand(rng, 4)) for _ in 1:n)
+end
+
+"""
+Return a vector of tuples of random four momenta, i.e. a collection of phase space points.
+n1 is the size of the phase space point, n2 is the number of points.
+"""
+function _rand_momenta(rng::AbstractRNG, n1, n2)
+    moms = Vector{NTuple{n1,SFourMomentum}}(undef, n2)
+    for i in 1:n2
+        moms[i] = _rand_momenta(rng, n1)
+    end
+    return moms
+end
+
+"""
+Return a random phase space point that is failing the incoming phase space constraint,
+i.e. the first entry of the phase space is the null momentum.
+"""
+function _rand_in_momenta_failing(rng::AbstractRNG, n)
+    return (zero(SFourMomentum), _rand_momenta(rng, n - 1)...)
+end
+
+"""
+Return a random phase space point that is failing the outgoing phase space constraint,
+i.e. the last entry of the phase space is the unit momentum.
+"""
+function _rand_out_momenta_failing(rng::AbstractRNG, n)
+    return (_rand_momenta(rng, n - 1)..., ones(SFourMomentum))
+end
+
+"""
+Return a collection of incoming phase space points, where the first point is failing the phase space constraint,
+i.e. the first entry of the vector is invalid but the others pass.
+n1 is the size of the phase space point, n2 is the number of points.
+"""
+function _rand_in_momenta_failing_mix(rng::AbstractRNG, n1, n2)
+    moms = _rand_momenta(rng, n1, n2)
+    moms[1] = _rand_in_momenta_failing(rng, n1)
+    return moms
+end
+
+"""
+Return a collection of incoming phase space points, where all points are failing the phase space constraint,
+i.e. their first entries are null momenta.
+n1 is the size of the phase space point, n2 is the number of points.
+"""
+function _rand_in_momenta_failing_all(rng::AbstractRNG, n1, n2)
+    moms = Vector{NTuple{n1,SFourMomentum}}(undef, n2)
+    for i in 1:n2
+        moms[i] = _rand_in_momenta_failing(rng, n1)
+    end
+    return moms
+end
+
+"""
+Return a vector of outgoing phase space points, where the first point is failing the phase space constraint,
+i.e. the last entry of the vector is invalid but the others pass.
+n1 is the size of the phase space point, n2 is the number of points.
+"""
+function _rand_out_momenta_failing_mix(rng::AbstractRNG, n1, n2)
+    moms = _rand_momenta(rng, n1, n2)
+    moms[end] = _rand_out_momenta_failing(rng, n1)
+    return moms
+end
+
+"""
+Return a vector of outgoing phase space points, where all points are failing the phase space constraint,
+i.e. their last entries are unit momenta.
+n1 is the size of the phase space point, n2 is the number of points.
+"""
+function _rand_out_momenta_failing_all(rng::AbstractRNG, n1, n2)
+    moms = Vector{NTuple{n1,SFourMomentum}}(undef, n2)
+    for i in 1:n2
+        moms[i] = _rand_out_momenta_failing(rng, n1)
+    end
+    return moms
+end

--- a/test/test_implementation/test_model.jl
+++ b/test/test_implementation/test_model.jl
@@ -1,5 +1,5 @@
 
 struct TestModel <: AbstractModelDefinition end
-QEDprocesses.fundamental_interaction_type(::TestModel) = :test_interaction
+QEDbase.fundamental_interaction_type(::TestModel) = :test_interaction
 
 struct TestModel_FAIL <: AbstractModelDefinition end

--- a/test/test_implementation/test_model.jl
+++ b/test/test_implementation/test_model.jl
@@ -1,0 +1,5 @@
+
+struct TestModel <: AbstractModelDefinition end
+QEDprocesses.fundamental_interaction_type(::TestModel) = :test_interaction
+
+struct TestModel_FAIL <: AbstractModelDefinition end

--- a/test/test_implementation/test_process.jl
+++ b/test/test_implementation/test_process.jl
@@ -1,0 +1,131 @@
+# dummy particles
+struct TestParticleFermion <: FermionLike end
+struct TestParticleBoson <: BosonLike end
+
+const PARTICLE_SET = [TestParticleFermion(), TestParticleBoson()]
+
+"""
+    TestProcess(rng,incoming_particles,outgoing_particles)
+
+"""
+struct TestProcess{IP<:Tuple,OP<:Tuple} <: AbstractProcessDefinition
+    incoming_particles::IP
+    outgoing_particles::OP
+end
+
+function TestProcess(rng::AbstractRNG, N_in::Int, N_out::Int)
+    in_particles = rand(rng, PARTICLE_SET, N_in)
+    out_particles = rand(rng, PARTICLE_SET, N_out)
+    return TestProcess(in_particles, out_particles)
+end
+
+QEDprocesses.incoming_particles(proc::TestProcess) = proc.incoming_particles
+QEDprocesses.outgoing_particles(proc::TestProcess) = proc.outgoing_particles
+
+struct TestProcess_FAIL{IP<:Tuple,OP<:Tuple} <: AbstractProcessDefinition
+    incoming_particles::IP
+    outgoing_particles::OP
+end
+
+function TestProcess_FAIL(rng::AbstractRNG, N_in::Int, N_out::Int)
+    in_particles = Tuple(rand(rng, PARTICLE_SET, N_in))
+    out_particles = Tuple(rand(rng, PARTICLE_SET, N_out))
+    return TestProcess_FAIL(in_particles, out_particles)
+end
+
+function QEDprocesses.in_phase_space_dimension(proc::TestProcess, ::TestModel)
+    return number_incoming_particles(proc) * 4
+end
+function QEDprocesses.out_phase_space_dimension(proc::TestProcess, ::TestModel)
+    return number_outgoing_particles(proc) * 4
+end
+
+"""
+Test process with no implemented interface. Should fail every usage except construction.
+"""
+struct TestProcess_FAIL_ALL{IP<:Tuple,OP<:Tuple} <: AbstractProcessDefinition
+    incoming_particles::IP
+    outgoing_particles::OP
+end
+
+function TestProcess_FAIL_ALL(rng::AbstractRNG, N_in::Int, N_out::Int)
+    in_particles = Tuple(rand(rng, PARTICLE_SET, N_in))
+    out_particles = Tuple(rand(rng, PARTICLE_SET, N_out))
+    return TestProcess_FAIL_ALL(in_particles, out_particles)
+end
+
+"""
+Test process with no implemented interface except the incoming and outgoing particles. 
+Should fail every usage except construction of itself and the respective phase space point for given four-momenta.
+"""
+struct TestProcess_FAIL_DIFFCS{IP<:Tuple,OP<:Tuple} <: AbstractProcessDefinition
+    incoming_particles::IP
+    outgoing_particles::OP
+end
+
+function TestProcess_FAIL_DIFFCS(rng::AbstractRNG, N_in::Int, N_out::Int)
+    in_particles = Tuple(rand(rng, PARTICLE_SET, N_in))
+    out_particles = Tuple(rand(rng, PARTICLE_SET, N_out))
+    return TestProcess_FAIL_DIFFCS(in_particles, out_particles)
+end
+
+QEDprocesses.incoming_particles(proc::TestProcess_FAIL_DIFFCS) = proc.incoming_particles
+QEDprocesses.outgoing_particles(proc::TestProcess_FAIL_DIFFCS) = proc.outgoing_particles
+
+# dummy phase space definition + failing phase space definition
+struct TestPhasespaceDef <: AbstractPhasespaceDefinition end
+struct TestPhasespaceDef_FAIL <: AbstractPhasespaceDefinition end
+
+# dummy implementation of the process interface
+
+function QEDprocesses._incident_flux(in_psp::InPhaseSpacePoint{<:TestProcess,<:TestModel})
+    return _groundtruth_incident_flux(momenta(in_psp, QEDbase.Incoming()))
+end
+
+function QEDprocesses._averaging_norm(proc::TestProcess)
+    return _groundtruth_averaging_norm(proc)
+end
+
+function QEDprocesses._matrix_element(psp::PhaseSpacePoint{<:TestProcess,TestModel})
+    in_ps = momenta(psp, QEDbase.Incoming())
+    out_ps = momenta(psp, QEDbase.Outgoing())
+    return _groundtruth_matrix_element(in_ps, out_ps)
+end
+
+function QEDprocesses._is_in_phasespace(psp::PhaseSpacePoint{<:TestProcess,TestModel})
+    in_ps = momenta(psp, QEDbase.Incoming())
+    out_ps = momenta(psp, QEDbase.Outgoing())
+    return _groundtruth_is_in_phasespace(in_ps, out_ps)
+end
+
+function QEDprocesses._phase_space_factor(
+    psp::PhaseSpacePoint{<:TestProcess,TestModel,TestPhasespaceDef}
+)
+    in_ps = momenta(psp, QEDbase.Incoming())
+    out_ps = momenta(psp, QEDbase.Outgoing())
+    return _groundtruth_phase_space_factor(in_ps, out_ps)
+end
+
+function QEDprocesses._generate_incoming_momenta(
+    proc::TestProcess,
+    model::TestModel,
+    phase_space_def::TestPhasespaceDef,
+    in_phase_space::NTuple{N,T},
+) where {N,T<:Real}
+    return _groundtruth_generate_momenta(in_phase_space)
+end
+
+function QEDprocesses._generate_outgoing_momenta(
+    proc::TestProcess,
+    model::TestModel,
+    phase_space_def::TestPhasespaceDef,
+    out_phase_space::NTuple{N,T},
+) where {N,T<:Real}
+    return _groundtruth_generate_momenta(out_phase_space)
+end
+
+function QEDprocesses._total_probability(
+    in_psp::InPhaseSpacePoint{<:TestProcess,<:TestModel,<:TestPhasespaceDef}
+)
+    return _groundtruth_total_probability(momenta(in_psp, QEDbase.Incoming()))
+end

--- a/test/test_implementation/test_process.jl
+++ b/test/test_implementation/test_process.jl
@@ -19,8 +19,8 @@ function TestProcess(rng::AbstractRNG, N_in::Int, N_out::Int)
     return TestProcess(in_particles, out_particles)
 end
 
-QEDprocesses.incoming_particles(proc::TestProcess) = proc.incoming_particles
-QEDprocesses.outgoing_particles(proc::TestProcess) = proc.outgoing_particles
+QEDbase.incoming_particles(proc::TestProcess) = proc.incoming_particles
+QEDbase.outgoing_particles(proc::TestProcess) = proc.outgoing_particles
 
 struct TestProcess_FAIL{IP<:Tuple,OP<:Tuple} <: AbstractProcessDefinition
     incoming_particles::IP
@@ -33,10 +33,10 @@ function TestProcess_FAIL(rng::AbstractRNG, N_in::Int, N_out::Int)
     return TestProcess_FAIL(in_particles, out_particles)
 end
 
-function QEDprocesses.in_phase_space_dimension(proc::TestProcess, ::TestModel)
+function QEDbase.in_phase_space_dimension(proc::TestProcess, ::TestModel)
     return number_incoming_particles(proc) * 4
 end
-function QEDprocesses.out_phase_space_dimension(proc::TestProcess, ::TestModel)
+function QEDbase.out_phase_space_dimension(proc::TestProcess, ::TestModel)
     return number_outgoing_particles(proc) * 4
 end
 
@@ -69,8 +69,8 @@ function TestProcess_FAIL_DIFFCS(rng::AbstractRNG, N_in::Int, N_out::Int)
     return TestProcess_FAIL_DIFFCS(in_particles, out_particles)
 end
 
-QEDprocesses.incoming_particles(proc::TestProcess_FAIL_DIFFCS) = proc.incoming_particles
-QEDprocesses.outgoing_particles(proc::TestProcess_FAIL_DIFFCS) = proc.outgoing_particles
+QEDbase.incoming_particles(proc::TestProcess_FAIL_DIFFCS) = proc.incoming_particles
+QEDbase.outgoing_particles(proc::TestProcess_FAIL_DIFFCS) = proc.outgoing_particles
 
 # dummy phase space definition + failing phase space definition
 struct TestPhasespaceDef <: AbstractPhasespaceDefinition end
@@ -78,27 +78,27 @@ struct TestPhasespaceDef_FAIL <: AbstractPhasespaceDefinition end
 
 # dummy implementation of the process interface
 
-function QEDprocesses._incident_flux(in_psp::InPhaseSpacePoint{<:TestProcess,<:TestModel})
+function QEDbase._incident_flux(in_psp::InPhaseSpacePoint{<:TestProcess,<:TestModel})
     return _groundtruth_incident_flux(momenta(in_psp, QEDbase.Incoming()))
 end
 
-function QEDprocesses._averaging_norm(proc::TestProcess)
+function QEDbase._averaging_norm(proc::TestProcess)
     return _groundtruth_averaging_norm(proc)
 end
 
-function QEDprocesses._matrix_element(psp::PhaseSpacePoint{<:TestProcess,TestModel})
+function QEDbase._matrix_element(psp::PhaseSpacePoint{<:TestProcess,TestModel})
     in_ps = momenta(psp, QEDbase.Incoming())
     out_ps = momenta(psp, QEDbase.Outgoing())
     return _groundtruth_matrix_element(in_ps, out_ps)
 end
 
-function QEDprocesses._is_in_phasespace(psp::PhaseSpacePoint{<:TestProcess,TestModel})
+function QEDbase._is_in_phasespace(psp::PhaseSpacePoint{<:TestProcess,TestModel})
     in_ps = momenta(psp, QEDbase.Incoming())
     out_ps = momenta(psp, QEDbase.Outgoing())
     return _groundtruth_is_in_phasespace(in_ps, out_ps)
 end
 
-function QEDprocesses._phase_space_factor(
+function QEDbase._phase_space_factor(
     psp::PhaseSpacePoint{<:TestProcess,TestModel,TestPhasespaceDef}
 )
     in_ps = momenta(psp, QEDbase.Incoming())
@@ -106,7 +106,7 @@ function QEDprocesses._phase_space_factor(
     return _groundtruth_phase_space_factor(in_ps, out_ps)
 end
 
-function QEDprocesses._generate_incoming_momenta(
+function QEDbase._generate_incoming_momenta(
     proc::TestProcess,
     model::TestModel,
     phase_space_def::TestPhasespaceDef,
@@ -115,7 +115,7 @@ function QEDprocesses._generate_incoming_momenta(
     return _groundtruth_generate_momenta(in_phase_space)
 end
 
-function QEDprocesses._generate_outgoing_momenta(
+function QEDbase._generate_outgoing_momenta(
     proc::TestProcess,
     model::TestModel,
     phase_space_def::TestPhasespaceDef,
@@ -124,7 +124,7 @@ function QEDprocesses._generate_outgoing_momenta(
     return _groundtruth_generate_momenta(out_phase_space)
 end
 
-function QEDprocesses._total_probability(
+function QEDbase._total_probability(
     in_psp::InPhaseSpacePoint{<:TestProcess,<:TestModel,<:TestPhasespaceDef}
 )
     return _groundtruth_total_probability(momenta(in_psp, QEDbase.Incoming()))

--- a/test/test_implementation/utils.jl
+++ b/test/test_implementation/utils.jl
@@ -1,0 +1,44 @@
+
+# Check if any failed type is in the input 
+_any_fail(x...) = true
+_any_fail(::TestProcess, ::TestModel) = false
+_any_fail(::TestProcess, ::TestModel, ::TestPhasespaceDef) = false
+
+# unrolls all elements of a list of four-momenta into vector of coordinates
+function _unroll_moms(ps_moms::AbstractVector{T}) where {T<:QEDbase.AbstractFourMomentum}
+    return collect(Iterators.flatten(ps_moms))
+end
+
+function _unroll_moms(ps_moms::AbstractMatrix{T}) where {T<:QEDbase.AbstractFourMomentum}
+    res = Matrix{eltype(T)}(undef, size(ps_moms, 1) * 4, size(ps_moms, 2))
+    for i in 1:size(ps_moms, 2)
+        res[:, i] .= _unroll_moms(view(ps_moms, :, i))
+    end
+    return res
+end
+
+flat_components(moms::AbstractVecOrMat) = _unroll_moms(moms)
+flat_components(moms::Tuple) = Tuple(_unroll_moms([moms...]))
+
+# collect components of four-momenta from a vector of coordinates
+function __furl_moms(ps_coords::AbstractVector{T}) where {T<:Real}
+    return SFourMomentum.(eachcol(reshape(ps_coords, 4, :)))
+end
+
+function _furl_moms(ps_coords::AbstractVector{T}) where {T<:Real}
+    @assert length(ps_coords) % 4 == 0
+    return __furl_moms(ps_coords)
+end
+
+function _furl_moms(ps_coords::AbstractMatrix{T}) where {T<:Real}
+    @assert size(ps_coords, 1) % 4 == 0
+    res = Matrix{SFourMomentum}(undef, Int(size(ps_coords, 1)//4), size(ps_coords, 2))
+    for i in 1:size(ps_coords, 2)
+        res[:, i] .= __furl_moms(view(ps_coords, :, i))
+    end
+    return res
+end
+
+function _furl_moms(moms::NTuple{N,Float64}) where {N}
+    return Tuple(_furl_moms(Vector{Float64}([moms...])))
+end


### PR DESCRIPTION
This adds generic implementations for total and differential cross-sections and probabilities based only on the interfaces. 

Most of the functionality is copied from `QEDprocesses`, but adjusted to use `AbstractPhaseSpacePoint` and such. 