### PR TITLE
Add momentum() function for psp

### DIFF
--- a/src/interfaces/phase_space_point.jl
+++ b/src/interfaces/phase_space_point.jl
@@ -114,51 +114,6 @@ function momentum(
     return _momentum_helper(particles(psp, dir), species, n)
 end
 
-function _assert_one_particle(
-    particles::Tuple{AbstractParticleStateful{DIR,SPECIES,EL},Vararg},
-    dir::DIR,
-    species::SPECIES,
-    n::Val{1},
-) where {DIR,SPECIES,EL}
-    throw(
-        InvalidInputError(
-            "momentum(): more than one $dir $species exists in this phase space point"
-        ),
-    )
-end
-
-function _assert_one_particle(
-    particles::Tuple{}, dir::DIR, species::SPECIES, n::Val{0}
-) where {DIR,SPECIES}
-    throw(
-        InvalidInputError("momentum(): no $dir $species exists in this phase space point")
-    )
-end
-
-function _assert_one_particle(
-    particles::Tuple{}, dir::DIR, species::SPECIES, n::Val{1}
-) where {DIR,SPECIES}
-    return nothing
-end
-
-function _assert_one_particle(
-    particles::Tuple{AbstractParticleStateful{DIR,SPECIES,EL},Vararg},
-    dir::DIR,
-    species::SPECIES,
-    n::Val{0},
-) where {DIR,SPECIES,EL}
-    return _assert_one_particle(particles[2:end], dir, species, Val(1))
-end
-
-function _assert_one_particle(
-    particles::Tuple{AbstractParticleStateful{DIR,SPECIES,EL},Vararg},
-    dir::DIR2,
-    species::SPECIES2,
-    n::Val{N},
-) where {DIR,SPECIES,EL,DIR2,SPECIES2,N}
-    return _assert_one_particle(particles[2:end], dir, species, n)
-end
-
 """
     momentum(psp::AbstractPhaseSpacePoint, dir::ParticleDirection, species::AbstractParticleType)
 
@@ -167,7 +122,13 @@ Returns the momentum of the particle in the given [`AbstractPhaseSpacePoint`](@r
 function momentum(
     psp::AbstractPhaseSpacePoint, dir::ParticleDirection, species::AbstractParticleType
 )
-    _assert_one_particle(particles(psp, dir), dir, species, Val(0))
+    if (number_particles(process(psp), dir, species) != 1)
+        throw(
+            InvalidInputError(
+                "this overload only works when exactly one $dir $species exists in the phase space point",
+            ),
+        )
+    end
 
     return momentum(psp, dir, species, Val(1))
 end

--- a/src/interfaces/phase_space_point.jl
+++ b/src/interfaces/phase_space_point.jl
@@ -125,7 +125,7 @@ function momentum(
     if (number_particles(process(psp), dir, species) != 1)
         throw(
             InvalidInputError(
-                "this overload only works when exactly one $dir $species exists in the phase space point",
+                "this overload only works when exactly one $dir $species exists in the phase space point, but $(number_paarticles(process(psp), dir, species)) exist in this one; to specify an index, use momentum(psp, dir, species, n)",
             ),
         )
     end


### PR DESCRIPTION
Adds functions 
```Julia
momentum(psp::AbstractPhaseSpacePoint, dir::ParticleDirection, species::AbstractParticleType, n::Val{N})
momentum(psp::AbstractPhaseSpacePoint, dir::ParticleDirection, species::AbstractParticleType, n::Int)
```
to get the momentum of the n-th particle of the given species and direction from the `AbstractPhaseSpacePoint`. I provided two overloads: One with a compile-time constant N via `Val{N}` and one with a normal `n::Int`. The first one adds no overhead and is compiled away completely, but only if the given value is actually a compile-time constant, such as a literal `1`. 
The second overload is implemented separately and is faster than the first when `n` is not a compile-time constant. It still takes ~40ns on my machine, versus ~1ns when the first overload is used. The first overload with a dynamic value (`Val(n)` on variable n) takes ~100ns.

Currently I can't add automated unit tests here yet, since the tests are in QEDcore still.