### PR TITLE
Add number_particles overloads

### DIFF
--- a/src/QEDbase.jl
+++ b/src/QEDbase.jl
@@ -106,8 +106,8 @@ include("particles/direction.jl")
 include("particles/spin_pol.jl")
 
 include("interfaces/phase_space.jl")
-include("interfaces/process.jl")
 include("interfaces/particle_stateful.jl")
+include("interfaces/process.jl")
 include("interfaces/phase_space_point.jl")
 
 include("cross_section/diff_probability.jl")

--- a/src/interfaces/process.jl
+++ b/src/interfaces/process.jl
@@ -206,31 +206,20 @@ Convenience function dispatching to [`number_incoming_particles`](@ref) or [`num
 Return the number of particles of the given direction and species in the given process definition.
 """
 @inline function number_particles(
-    proc_def::AbstractProcessDefinition, dir::DIR, ::PT
+    proc_def::AbstractProcessDefinition, dir::DIR, species::PT
 ) where {DIR<:ParticleDirection,PT<:AbstractParticleType}
     return count(x -> x isa PT, particles(proc_def, dir))
 end
 
 """
     number_particles(proc_def::AbstractProcessDefinition, particle::AbstractParticleStateful)
-    number_particles(proc_def::AbstractProcessDefinition, particle_type::Type{AbstractParticleStateful})
 
 Return the number of particles of the given particle's direction and species in the given process definition.
 """
 @inline function number_particles(
-    proc_def::AbstractProcessDefinition, ::AbstractParticleStateful{DIR,PT,EL}
-) where {DIR<:ParticleDirection,PT<:AbstractParticleType,EL<:AbstractFourMomentum}
-    return number_particles(proc_def, DIR(), PT())
-end
-@inline function number_particles(
-    proc_def::AbstractProcessDefinition, ::Type{PS}
-) where {
-    DIR<:ParticleDirection,
-    PT<:AbstractParticleType,
-    EL<:AbstractFourMomentum,
-    PS<:AbstractParticleStateful{DIR,PT,EL},
-}
-    return number_particles(proc_def, DIR(), PT())
+    proc_def::AbstractProcessDefinition, ps::AbstractParticleStateful
+)
+    return number_particles(proc_def, particle_direction(ps), particle_species(ps))
 end
 
 #####

--- a/src/interfaces/process.jl
+++ b/src/interfaces/process.jl
@@ -191,14 +191,47 @@ Convenience function dispatching to [`incoming_particles`](@ref) or [`outgoing_p
     outgoing_particles(proc_def)
 
 """
-    number_particles(proc_def::AbstractProcessDefinition, ::ParticleDirection)
+    number_particles(proc_def::AbstractProcessDefinition, dir::ParticleDirection)
 
-Convenience function dispatching to [`number_incoming_particles`](@ref) or [`number_outgoing_particles`](@ref) depending on the given direction.
+Convenience function dispatching to [`number_incoming_particles`](@ref) or [`number_outgoing_particles`](@ref) depending on the given direction, returning the number of incoming or outgoing particles, respectively.
 """
 @inline number_particles(proc_def::AbstractProcessDefinition, ::Incoming) =
     number_incoming_particles(proc_def)
 @inline number_particles(proc_def::AbstractProcessDefinition, ::Outgoing) =
     number_outgoing_particles(proc_def)
+
+"""
+    number_particles(proc_def::AbstractProcessDefinition, dir::ParticleDirection, species::AbstractParticleType)
+
+Return the number of particles of the given direction and species in the given process definition.
+"""
+@inline function number_particles(
+    proc_def::AbstractProcessDefinition, dir::DIR, ::PT
+) where {DIR<:ParticleDirection,PT<:AbstractParticleType}
+    return count(x -> x isa PT, particles(proc_def, dir))
+end
+
+"""
+    number_particles(proc_def::AbstractProcessDefinition, particle::AbstractParticleStateful)
+    number_particles(proc_def::AbstractProcessDefinition, particle_type::Type{AbstractParticleStateful})
+
+Return the number of particles of the given particle's direction and species in the given process definition.
+"""
+@inline function number_particles(
+    proc_def::AbstractProcessDefinition, ::AbstractParticleStateful{DIR,PT,EL}
+) where {DIR<:ParticleDirection,PT<:AbstractParticleType,EL<:AbstractFourMomentum}
+    return number_particles(proc_def, DIR(), PT())
+end
+@inline function number_particles(
+    proc_def::AbstractProcessDefinition, ::Type{PS}
+) where {
+    DIR<:ParticleDirection,
+    PT<:AbstractParticleType,
+    EL<:AbstractFourMomentum,
+    PS<:AbstractParticleStateful{DIR,PT,EL},
+}
+    return number_particles(proc_def, DIR(), PT())
+end
 
 #####
 # Generation of four-momenta from coordinates


### PR DESCRIPTION
Add functions:
```Julia
number_particles(proc_def::AbstractProcessDefinition, dir::ParticleDirection, species::AbstractParticleType)
number_particles(proc_def::AbstractProcessDefinition, particle::AbstractParticleStateful)
number_particles(proc_def::AbstractProcessDefinition, particle_type::Type{AbstractParticleStateful})
```

Closes #89
