### PR TITLE
Update CI Julia version

### DIFF
--- a/.github/workflows/BuildDeployDoc.yml
+++ b/.github/workflows/BuildDeployDoc.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.9'
+          version: '1.10'
       - name: Add custom registry 
         run: |
           julia --project=docs/ -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/QEDjl-project/registry.git"));'

--- a/.github/workflows/formatter.yaml
+++ b/.github/workflows/formatter.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: install Julia
         uses: julia-actions/setup-julia@v1
         with:
-          version: 1.9
+          version: 1.10
       - name: Install Julia requirements
         run: julia --project=${GITHUB_WORKSPACE}/.formatting -e 'import Pkg; Pkg.instantiate()'
       - name: Check code style

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ unit_tests_releases:
   extends: .untit_test_template
   parallel:
     matrix:
-      - JULIA_VERSION: ["1.6", "1.7", "1.8", "1.9"]
+      - JULIA_VERSION: ["1.6", "1.7", "1.8", "1.9", "1.10", "rc"]
   image: julia:$JULIA_VERSION
 
 unit_tests_nightly:
@@ -65,7 +65,7 @@ unit_tests_nightly:
     - cpuonly
 
 generate_integration_tests:
-  image: julia:1.9
+  image: julia:1.10
   stage: generate_integration_test
   script:
     # extract package name
@@ -104,8 +104,8 @@ run_integration_tests:
         job: generate_integration_tests
     strategy: depend
 
-verify-unit-test-deps_julia1.9:
-  image: julia:1.9
+verify-unit-test-deps_julia1.10:
+  image: julia:1.10
   stage: verify-unit-test-deps
   script:
     - apt update && apt install -y git


### PR DESCRIPTION
Use 1.10 by default for docs building and formatting, extend used versions by 1.10 and release candidate for unit tests.