### PR TITLE
Spin and Polarization Interface for AbstractProcessDefinition

### DIFF
--- a/src/QEDbase.jl
+++ b/src/QEDbase.jl
@@ -63,6 +63,7 @@ export AbstractModelDefinition, fundamental_interaction_type
 export AbstractProcessDefinition, incoming_particles, outgoing_particles
 export number_incoming_particles, number_outgoing_particles
 export particles, number_particles
+export incoming_spin_pol, outgoing_spin_pol, spin_pol
 
 # Abstract phase space definition interface
 export AbstractCoordinateSystem, AbstractFrameOfReference, AbstractPhasespaceDefinition

--- a/src/QEDbase.jl
+++ b/src/QEDbase.jl
@@ -63,7 +63,7 @@ export AbstractModelDefinition, fundamental_interaction_type
 export AbstractProcessDefinition, incoming_particles, outgoing_particles
 export number_incoming_particles, number_outgoing_particles
 export particles, number_particles
-export incoming_spin_pol, outgoing_spin_pol, spin_pol
+export incoming_spin_pols, outgoing_spin_pols, spin_pols
 
 # Abstract phase space definition interface
 export AbstractCoordinateSystem, AbstractFrameOfReference, AbstractPhasespaceDefinition

--- a/src/interfaces/process.jl
+++ b/src/interfaces/process.jl
@@ -21,12 +21,12 @@ An `AbstractProcessDefinition` is also expected to contain spin and polarization
 For this, the functions
 
 ```Julia
-incoming_spin_pol(proc_def::AbstractProcessDefinition)
-outgoing_spin_pol(proc_def::AbstractProcessDefinition)
+incoming_spin_pols(proc_def::AbstractProcessDefinition)
+outgoing_spin_pols(proc_def::AbstractProcessDefinition)
 ```
 
 can be overloaded. They must return a tuple of [`AbstractSpinOrPolarization`], where the order must match the order of the process' particles.
-A default implementation is provided which assumes [`AllSpin`](@ref) for every [`is_fermion`](@ref) particle and [`AllPol`](@ref) for every [`is_boson`](@ref) particle.
+A default implementation is provided which assumes [`AllSpin`](@ref) for every [`is_fermion`](@ref) particle and [`AllPolarization`](@ref) for every [`is_boson`](@ref) particle.
 
 Furthermore, to calculate scattering probabilities and differential cross sections, the following 
 interface functions need to be implemented for every combination of `CustomProcess<:AbstractProcessDefinition`, 
@@ -80,24 +80,24 @@ See also: [`AbstractParticleType`](@ref)
 function outgoing_particles end
 
 """
-    incoming_spin_pol(proc_def::AbstractProcessDefinition)
+    incoming_spin_pols(proc_def::AbstractProcessDefinition)
 
 Interface function for scattering processes. Return the tuple of spins or polarizations for the given process definition. The order must be the same as the particles returned from [`incoming_particles`](@ref).
 A default implementation is provided, returning [`AllSpin`](@ref) for every [`is_fermion`](@ref) and [`AllPolarization`](@ref) for every [`is_boson`](@ref).
 
 See also: [`AbstractSpinOrPolarization`](@ref)
 """
-function incoming_spin_pol end
+function incoming_spin_pols end
 
 """
-    outgoing_spin_pol(proc_def::AbstractProcessDefinition)
+    outgoing_spin_pols(proc_def::AbstractProcessDefinition)
 
 Interface function for scattering processes. Return the tuple of spins or polarizations for the given process definition. The order must be the same as the particles returned from [`outgoing_particles`](@ref).
 A default implementation is provided, returning [`AllSpin`](@ref) for every [`is_fermion`](@ref) and [`AllPolarization`](@ref) for every [`is_boson`](@ref).
 
 See also: [`AbstractSpinOrPolarization`](@ref)
 """
-function outgoing_spin_pol end
+function outgoing_spin_pols end
 
 """
     _incident_flux(in_psp::InPhaseSpacePoint{PROC,MODEL}) where {
@@ -258,7 +258,7 @@ Return the number of particles of the given particle's direction and species in 
 end
 
 # default implementation
-function incoming_spin_pol(proc_def::AbstractProcessDefinition)
+function incoming_spin_pols(proc_def::AbstractProcessDefinition)
     return ntuple(
         x -> is_fermion(incoming_particles(proc_def)[x]) ? AllSpin() : AllPolarization(),
         number_incoming_particles(proc_def),
@@ -266,7 +266,7 @@ function incoming_spin_pol(proc_def::AbstractProcessDefinition)
 end
 
 # default implementation
-function outgoing_spin_pol(proc_def::AbstractProcessDefinition)
+function outgoing_spin_pols(proc_def::AbstractProcessDefinition)
     return ntuple(
         x -> is_fermion(outgoing_particles(proc_def)[x]) ? AllSpin() : AllPolarization(),
         number_outgoing_particles(proc_def),
@@ -274,12 +274,12 @@ function outgoing_spin_pol(proc_def::AbstractProcessDefinition)
 end
 
 """
-    spin_pol(proc_def::AbstractProcessDefinition, dir::ParticleDirection)
+    spin_pols(proc_def::AbstractProcessDefinition, dir::ParticleDirection)
 
-Return the tuple of spins and polarizations for the process in the given direction. Dispatches to [`incoming_spin_pol`](@ref) or [`outgoing_spin_pol`](@ref).
+Return the tuple of spins and polarizations for the process in the given direction. Dispatches to [`incoming_spin_pols`](@ref) or [`outgoing_spin_pols`](@ref).
 """
-spin_pol(proc_def::AbstractProcessDefinition, dir::Incoming) = incoming_spin_pol(proc_def)
-spin_pol(proc_def::AbstractProcessDefinition, dir::Outgoing) = outgoing_spin_pol(proc_def)
+spin_pols(proc_def::AbstractProcessDefinition, dir::Incoming) = incoming_spin_pols(proc_def)
+spin_pols(proc_def::AbstractProcessDefinition, dir::Outgoing) = outgoing_spin_pols(proc_def)
 
 #####
 # Generation of four-momenta from coordinates

--- a/src/interfaces/process.jl
+++ b/src/interfaces/process.jl
@@ -17,6 +17,17 @@ outgoing_particles(proc_def::AbstractProcessDefinition)
 
 which return a tuple of the incoming and outgoing particles, respectively.
 
+An `AbstractProcessDefinition` is also expected to contain spin and polarization information of its particles.
+For this, the functions
+
+```Julia
+incoming_spin_pol(proc_def::AbstractProcessDefinition)
+outgoing_spin_pol(proc_def::AbstractProcessDefinition)
+```
+
+can be overloaded. They must return a tuple of [`AbstractSpinOrPolarization`], where the order must match the order of the process' particles.
+A default implementation is provided which assumes [`AllSpin`](@ref) for every [`is_fermion`](@ref) particle and [`AllPol`](@ref) for every [`is_boson`](@ref) particle.
+
 Furthermore, to calculate scattering probabilities and differential cross sections, the following 
 interface functions need to be implemented for every combination of `CustomProcess<:AbstractProcessDefinition`, 
 `CustomModel<:AbstractModelDefinition`, and `CustomPhasespaceDefinition<:AbstractPhasespaceDefinition`.

--- a/test/interfaces/process.jl
+++ b/test/interfaces/process.jl
@@ -100,6 +100,15 @@ include("../test_implementation/TestImplementation.jl")
         @test outgoing_spin_pol(TESTPROC) == groundtruth_outgoing_spin_pols
         @test spin_pol(TESTPROC, Incoming()) == groundtruth_incoming_spin_pols
         @test spin_pol(TESTPROC, Outgoing()) == groundtruth_outgoing_spin_pols
+
+        for (pt, sp) in Iterators.flatten((
+            Iterators.zip(incoming_particles(TESTPROC), incoming_spin_pol(TESTPROC)),
+            Iterators.zip(outgoing_particles(TESTPROC), outgoing_spin_pol(TESTPROC)),
+        ))
+            @test is_boson(pt) ? sp isa AbstractPolarization : true
+            @test is_fermion(pt) ? sp isa AbstractSpin : true
+            @test is_boson(pt) || is_fermion(pt)
+        end
     end
 
     @testset "incident flux" begin

--- a/test/interfaces/process.jl
+++ b/test/interfaces/process.jl
@@ -34,8 +34,8 @@ include("../test_implementation/TestImplementation.jl")
         @testset "failed process interface" begin
             @test_throws MethodError incoming_particles(TESTPROC_FAIL_ALL)
             @test_throws MethodError outgoing_particles(TESTPROC_FAIL_ALL)
-            @test_throws MethodError incoming_spin_pol(TESTPROC_FAIL_ALL)
-            @test_throws MethodError outgoing_spin_pol(TESTPROC_FAIL_ALL)
+            @test_throws MethodError incoming_spin_pols(TESTPROC_FAIL_ALL)
+            @test_throws MethodError outgoing_spin_pols(TESTPROC_FAIL_ALL)
         end
 
         @testset "$PROC $MODEL" for (PROC, MODEL) in Iterators.product(
@@ -96,14 +96,14 @@ include("../test_implementation/TestImplementation.jl")
             N_OUTGOING,
         )
 
-        @test incoming_spin_pol(TESTPROC) == groundtruth_incoming_spin_pols
-        @test outgoing_spin_pol(TESTPROC) == groundtruth_outgoing_spin_pols
-        @test spin_pol(TESTPROC, Incoming()) == groundtruth_incoming_spin_pols
-        @test spin_pol(TESTPROC, Outgoing()) == groundtruth_outgoing_spin_pols
+        @test incoming_spin_pols(TESTPROC) == groundtruth_incoming_spin_pols
+        @test outgoing_spin_pols(TESTPROC) == groundtruth_outgoing_spin_pols
+        @test spin_pols(TESTPROC, Incoming()) == groundtruth_incoming_spin_pols
+        @test spin_pols(TESTPROC, Outgoing()) == groundtruth_outgoing_spin_pols
 
         for (pt, sp) in Iterators.flatten((
-            Iterators.zip(incoming_particles(TESTPROC), incoming_spin_pol(TESTPROC)),
-            Iterators.zip(outgoing_particles(TESTPROC), outgoing_spin_pol(TESTPROC)),
+            Iterators.zip(incoming_particles(TESTPROC), incoming_spin_pols(TESTPROC)),
+            Iterators.zip(outgoing_particles(TESTPROC), outgoing_spin_pols(TESTPROC)),
         ))
             @test is_boson(pt) ? sp isa AbstractPolarization : true
             @test is_fermion(pt) ? sp isa AbstractSpin : true

--- a/test/interfaces/process.jl
+++ b/test/interfaces/process.jl
@@ -34,6 +34,8 @@ include("../test_implementation/TestImplementation.jl")
         @testset "failed process interface" begin
             @test_throws MethodError incoming_particles(TESTPROC_FAIL_ALL)
             @test_throws MethodError outgoing_particles(TESTPROC_FAIL_ALL)
+            @test_throws MethodError incoming_spin_pol(TESTPROC_FAIL_ALL)
+            @test_throws MethodError outgoing_spin_pol(TESTPROC_FAIL_ALL)
         end
 
         @testset "$PROC $MODEL" for (PROC, MODEL) in Iterators.product(
@@ -82,6 +84,22 @@ include("../test_implementation/TestImplementation.jl")
             @test number_particles(TESTPROC, dir, species) == groundtruth_particle_count
             @test number_particles(TESTPROC, test_ps) == groundtruth_particle_count
         end
+    end
+
+    @testset "incoming/outgoing spins and polarizations" begin
+        groundtruth_incoming_spin_pols = ntuple(
+            x -> is_fermion(INCOMING_PARTICLES[x]) ? AllSpin() : AllPolarization(),
+            N_INCOMING,
+        )
+        groundtruth_outgoing_spin_pols = ntuple(
+            x -> is_fermion(OUTGOING_PARTICLES[x]) ? AllSpin() : AllPolarization(),
+            N_OUTGOING,
+        )
+
+        @test incoming_spin_pol(TESTPROC) == groundtruth_incoming_spin_pols
+        @test outgoing_spin_pol(TESTPROC) == groundtruth_outgoing_spin_pols
+        @test spin_pol(TESTPROC, Incoming()) == groundtruth_incoming_spin_pols
+        @test spin_pol(TESTPROC, Outgoing()) == groundtruth_outgoing_spin_pols
     end
 
     @testset "incident flux" begin


### PR DESCRIPTION
Adds the functions `incoming_spin_pol`, `outgoing_spin_pol`, and `spin_pol` to the `AbstractProcessDefinition` interface. These can be implemented by specific processes, or rely on the provided default implementation which returns `AllSpin` or `AllPol` for each particle.

Closes #105
