### PR TITLE
Fix GPU incompatability of `momenta` implementation

### DIFF
--- a/src/interfaces/phase_space_point.jl
+++ b/src/interfaces/phase_space_point.jl
@@ -171,12 +171,8 @@ end
 
 Return a `Tuple` of all the particles' momenta for the given `ParticleDirection`.
 """
-function momenta(psp::AbstractPhaseSpacePoint, ::QEDbase.Incoming)
-    return momentum.(particles(psp, QEDbase.Incoming()))
-end
-
-function momenta(psp::AbstractPhaseSpacePoint, ::QEDbase.Outgoing)
-    return momentum.(particles(psp, QEDbase.Outgoing()))
+function momenta(psp::AbstractPhaseSpacePoint, dir::ParticleDirection)
+    return ntuple(i -> momentum(psp[dir, i]), number_particles(process(psp), dir))
 end
 
 """


### PR DESCRIPTION
Rewrite momenta function without broadcast, because GPUs do not like broadcasts in their kernels.
This is essentially ported from https://github.com/QEDjl-project/QEDprocesses.jl/pull/69 since this implementation moved here since that PR was opened.