### PR TITLE
CI: set QED dependencies for doc build to dev branch version, if target branch is not main

### DIFF
--- a/.github/workflows/BuildDeployDoc.yml
+++ b/.github/workflows/BuildDeployDoc.yml
@@ -25,6 +25,11 @@ jobs:
           julia --project=docs/ -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"));'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: set dependencies to dev branch version
+        if: (github.event_name == 'push' && github.ref_name != 'main') || (github.event_name == 'pull_request' && github.base_ref != 'main')
+        run: |
+          git clone -b dev https://github.com/QEDjl-project/QED.jl.git /tmp/integration_test_tools
+          julia --project=docs/ /tmp/integration_test_tools/.ci/set_dev_dependencies.jl
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,11 +9,6 @@ Pkg.develop(; path=project_path)
 using Documenter
 using QEDbase
 
-#DocMeta.setdocmeta!(QEDbase, :DocTestSetup, :(using QEDbase); recursive=true)
-
-# TODO: remove before release
-Pkg.add(; url="https://github.com/QEDjl-project/QEDcore.jl", rev="dev")
-
 using DocumenterCitations
 
 bib = CitationBibliography(joinpath(@__DIR__, "Bibliography.bib"))
@@ -41,6 +36,9 @@ makedocs(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://qedjl-project.gitlab.io/QEDbase.jl",
         assets=String[],
+        # TODO: workaround
+        # should be fixed: https://github.com/QEDjl-project/QEDbase.jl/issues/4
+        size_threshold_ignore=["index.md"],
     ),
     pages=pages,
     plugins=[bib],


### PR DESCRIPTION
Copy of: https://github.com/QEDjl-project/QEDprocesses.jl/pull/95