### PR TITLE
CI: modify compat entries in docs build and integration tests

### DIFF
--- a/.github/workflows/BuildDeployDoc.yml
+++ b/.github/workflows/BuildDeployDoc.yml
@@ -19,14 +19,18 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1.10'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: set dependencies to dev branch version
-        if: (github.event_name == 'push' && github.ref_name != 'main') || (github.event_name == 'pull_request' && github.base_ref != 'main')
+      - name: clone integration test tools
         run: |
-          git clone -b dev https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git /tmp/integration_test_tools
-          julia --project=docs/ /tmp/integration_test_tools/.ci/set_dev_dependencies.jl
+          git clone --depth 1 -b dev https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git /tmp/integration_test_tools/
+      - name: set dev dependencies
+        run: |
+          $(julia --project=. /tmp/integration_test_tools/.ci/integTestGen/src/get_project_name_version_path.jl)
+          echo "CI_DEV_PKG_NAME -> $CI_DEV_PKG_NAME"
+          echo "CI_DEV_PKG_VERSION -> $CI_DEV_PKG_VERSION"
+          echo "CI_DEV_PKG_PATH -> $CI_DEV_PKG_PATH"
+          julia --project=docs/ /tmp/integration_test_tools/.ci/SetupDevEnv/src/SetupDevEnv.jl
+          julia --project=docs/ -e 'import Pkg; Pkg.instantiate()'
       - name: Build and deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: julia --project=docs/ docs/make.jl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,13 +8,17 @@ stages:
   stage: unit-test
   script:
     - apt update && apt install -y git
-    - git clone --depth 1 -b dev https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git /QEDjl
+    - git clone --depth 1 -b dev https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git /tmp/integration_test_tools/
+    - $(julia --project=. /tmp/integration_test_tools/.ci/integTestGen/src/get_project_name_version_path.jl)
+    - echo "CI_DEV_PKG_NAME -> $CI_DEV_PKG_NAME"
+    - echo "CI_DEV_PKG_VERSION -> $CI_DEV_PKG_VERSION"
+    - echo "CI_DEV_PKG_PATH -> $CI_DEV_PKG_PATH"
     - >
       if [[ $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_BRANCH == "dev" || $CI_COMMIT_REF_NAME == "dev" ]]; then
         # set name of the commit message from CI_COMMIT_MESSAGE to NO_MESSAGE, that the script does not read accidentally custom packages from the commit message of a merge commit
-        julia --project=. /QEDjl/.ci/SetupDevEnv/src/SetupDevEnv.jl ${CI_PROJECT_DIR}/Project.toml NO_MESSAGE
+        julia --project=. /tmp/integration_test_tools/.ci/SetupDevEnv/src/SetupDevEnv.jl ${CI_PROJECT_DIR}/Project.toml NO_MESSAGE
       else
-        julia --project=. /QEDjl/.ci/SetupDevEnv/src/SetupDevEnv.jl ${CI_PROJECT_DIR}/Project.toml
+        julia --project=. /tmp/integration_test_tools/.ci/SetupDevEnv/src/SetupDevEnv.jl ${CI_PROJECT_DIR}/Project.toml
       fi
     - julia --project=. -e 'import Pkg; Pkg.instantiate()'
     - julia --project=. -e 'import Pkg; Pkg.test(; coverage = true)'
@@ -67,10 +71,12 @@ generate_integration_tests:
   stage: generate_integration_test
   script:
     # extract package name
-    - export CI_DEPENDENCY_NAME=$(cat $CI_PROJECT_DIR/Project.toml | grep name | awk '{ print $3 }' | tr -d '"')
-    - echo "CI_DEPENDENCY_NAME -> $CI_DEPENDENCY_NAME"
     - apt update && apt install -y git
     - git clone --depth 1 -b dev https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git /QEDjl
+    - $(julia --project /QEDjl/.ci/integTestGen/src/get_project_name_version_path.jl)
+    - echo "CI_DEV_PKG_NAME -> $CI_DEV_PKG_NAME"
+    - echo "CI_DEV_PKG_VERSION -> $CI_DEV_PKG_VERSION"
+    - echo "CI_DEV_PKG_PATH -> $CI_DEV_PKG_PATH"
     - cd /QEDjl/.ci/integTestGen/
     - julia --project=. -e 'import Pkg; Pkg.instantiate()'
     # paths of artifacts are relative to CI_PROJECT_DIR


### PR DESCRIPTION
Use overworked CI script to setup dev branch Julia environment. The CI scripts allows to resolve circular dependencies and modify compat entries of dependencies, if own project version was updated.

- [x] requires this PR https://github.com/QEDjl-project/QuantumElectrodynamics.jl/pull/74