### PR TITLE
Add assumptions to make vector and matrix *() :total

### DIFF
--- a/src/interfaces/lorentz_vectors/arithmetic.jl
+++ b/src/interfaces/lorentz_vectors/arithmetic.jl
@@ -120,9 +120,11 @@ Return the the invariant mass of a given `LorentzVectorLike`, i.e. the square ro
 
 """
 @traitfn function getInvariantMass(lv::T) where {T; IsLorentzVectorLike{T}}
+    # assume nothrow since we make sure that sqrt is only called on positive values
+    Base.@assume_effects :nothrow
     m2 = getInvariantMass2(lv)
     if m2 < zero(m2)
-        # Think about including this waring, maybe optional with a global PRINT_WARINGS switch.
+        # Think about including this warning, maybe optional with a global PRINT_WARNINGS switch.
         #@warn("The square of the invariant mass (m2=P*P) is negative. The value -sqrt(-m2) is returned.")
         return -sqrt(-m2)
     else
@@ -319,7 +321,7 @@ Return the transverse momentum for a given `LorentzVectorLike`, i.e. the square 
 @traitfn function getTransverseMass(lv::T) where {T; IsLorentzVectorLike{T}}
     mT2 = getTransverseMass2(lv)
     if mT2 < zero(mT2)
-        # add optional waring: negative transverse mass -> -sqrt(-mT2) is returned.
+        # add optional warning: negative transverse mass -> -sqrt(-mT2) is returned.
         -sqrt(-mT2)
     else
         sqrt(mT2)

--- a/src/interfaces/lorentz_vectors/dirac_interaction.jl
+++ b/src/interfaces/lorentz_vectors/dirac_interaction.jl
@@ -11,7 +11,9 @@ Product of generic Lorentz vector with a Dirac tensor from the left. Basically, 
 function _mul(
     DM::T, L::TL
 ) where {T<:Union{AbstractDiracMatrix,AbstractDiracVector},TL<:AbstractLorentzVector}
-    return constructorof(TL)(DM * L[1], DM * L[2], DM * L[3], DM * L[4])
+    # constructorof doesn't guarantee inaccessiblememonly but it is safe to assume here
+    Base.@assume_effects :inaccessiblememonly
+    return @inbounds constructorof(TL)(DM * L[1], DM * L[2], DM * L[3], DM * L[4])
 end
 @inline function *(
     DM::T, L::TL
@@ -31,7 +33,9 @@ Product of generic Lorentz vector with a Dirac tensor from the right. Basically,
 function _mul(
     L::TL, DM::T
 ) where {TL<:AbstractLorentzVector,T<:Union{AbstractDiracMatrix,AbstractDiracVector}}
-    return constructorof(TL)(L[1] * DM, L[2] * DM, L[3] * DM, L[4] * DM)
+    # constructorof doesn't guarantee inaccessiblememonly but it is safe to assume here
+    Base.@assume_effects :inaccessiblememonly
+    return @inbounds constructorof(TL)(L[1] * DM, L[2] * DM, L[3] * DM, L[4] * DM)
 end
 @inline function *(
     L::TL, DM::T


### PR DESCRIPTION
Having these functions infer `:nothrow` correctly by the compiler can significantly help with optimization in the compiler, so eventually we should try to make sure that most of QEDbase functionality has as many effects inferred as possible.

I've added comments explaining the assumed effects and why they are correct. We should probably have this as a guideline for `@assume_effects` in general.