### PR TITLE
extension of _build_momenta

### DIFF
--- a/src/QEDbase.jl
+++ b/src/QEDbase.jl
@@ -120,6 +120,7 @@ include("interfaces/phase_space_point.jl")
 
 include("interfaces/coordinate_transformation.jl")
 
+include("implementations/phase_space_layout/checks.jl")
 include("implementations/phase_space_layout/build_momenta.jl")
 
 include("implementations/process/particles.jl")

--- a/src/implementations/phase_space_layout/build_momenta.jl
+++ b/src/implementations/phase_space_layout/build_momenta.jl
@@ -4,31 +4,6 @@
 #############
 
 ### in ps layout
-
-function _build_momenta(
-    ::Val{Nc},
-    proc::AbstractProcessDefinition,
-    model::AbstractModelDefinition,
-    in_psl::AbstractInPhaseSpaceLayout,
-    in_coords::NTuple{N},
-) where {Nc,N}
-    throw(
-        InvalidInputError(
-            "number of coordinates <$N> must be the same as the phase-space dimension <$Nc>"
-        ),
-    )
-end
-
-function _build_momenta(
-    ::Val{Nc},
-    proc::AbstractProcessDefinition,
-    model::AbstractModelDefinition,
-    in_psl::AbstractInPhaseSpaceLayout,
-    in_coords::NTuple{Nc,T},
-) where {Nc,T}
-    return _build_momenta(proc, model, in_psl, in_coords)
-end
-
 """
     build_momenta(proc, model, in_psl::AbstractInPhaseSpaceLayout, in_coords::Tuple)
 
@@ -53,9 +28,8 @@ function build_momenta(
     in_psl::AbstractInPhaseSpaceLayout,
     in_coords::Tuple,
 )
-    return _build_momenta(
-        Val(phase_space_dimension(proc, model, in_psl)), proc, model, in_psl, in_coords
-    )
+    _check_phase_space_dimension(Val(phase_space_dimension(proc, model, in_psl)), in_coords)
+    return _build_momenta(proc, model, in_psl, in_coords)
 end
 
 """
@@ -91,71 +65,6 @@ end
 
 ### out ps layout
 
-function _build_momenta(
-    ::Val{Nc},
-    proc::AbstractProcessDefinition,
-    model::AbstractModelDefinition,
-    in_moms::NTuple{NIN,<:AbstractFourMomentum},
-    out_psl::AbstractOutPhaseSpaceLayout,
-    out_coords::NTuple{N},
-) where {Nc,N,NIN}
-    throw(
-        InvalidInputError(
-            "number of coordinates <$N> must be the same as the out-phase-space dimension <$Nc>",
-        ),
-    )
-end
-
-function _build_momenta(
-    ::Val{Nc},
-    proc::AbstractProcessDefinition,
-    model::AbstractModelDefinition,
-    in_moms::NTuple{NIN,<:AbstractFourMomentum},
-    out_psl::AbstractOutPhaseSpaceLayout,
-    out_coords::NTuple{Nc,T},
-) where {Nc,NIN,T<:Real}
-    return _build_momenta(proc, model, in_moms, out_psl, out_coords)
-end
-
-function _build_momenta(
-    ::Val{Ncin},
-    ::Val{Ncout},
-    proc::AbstractProcessDefinition,
-    model::AbstractModelDefinition,
-    out_psl::AbstractOutPhaseSpaceLayout,
-    in_coords::NTuple{N1,T},
-    out_coords::NTuple{N2,T},
-) where {Ncin,Ncout,N1,N2,T<:Real}
-    err_msg = ""
-
-    if Ncin != N1
-        err_msg =
-            err_msg *
-            "number of in coordinates <$N1> must be the same as the in-phase-space dimension <$Ncin>\n"
-    end
-
-    if Ncout != N2
-        err_msg =
-            err_msg *
-            "number of out coordinates <$N2> must be the same as the out-phase-space dimension <$Ncout>"
-    end
-
-    throw(InvalidInputError(err_msg))
-end
-
-function _build_momenta(
-    ::Val{Ncin},
-    ::Val{Ncout},
-    proc::AbstractProcessDefinition,
-    model::AbstractModelDefinition,
-    out_psl::AbstractOutPhaseSpaceLayout,
-    in_coords::NTuple{Ncin,T},
-    out_coords::NTuple{Ncout,T},
-) where {Ncin,Ncout,T<:Real}
-    in_moms = _build_momenta(proc, model, in_phase_space_layout(out_psl), in_coords)
-    return in_moms, _build_momenta(proc, model, in_moms, out_psl, out_coords)
-end
-
 # this only exists, since the constructor of `QEDcore.PhaseSpacePoint` calls it and not
 # build_momenta(...) without the underscore
 function _build_momenta(
@@ -165,15 +74,8 @@ function _build_momenta(
     in_coords::NTuple{Ncin,T},
     out_coords::NTuple{Ncout,T},
 ) where {Ncin,Ncout,T<:Real}
-    return _build_momenta(
-        Val(phase_space_dimension(proc, model, in_phase_space_layout(out_psl))),
-        Val(phase_space_dimension(proc, model, out_psl)),
-        proc,
-        model,
-        out_psl,
-        in_coords,
-        out_coords,
-    )
+    in_moms = _build_momenta(proc, model, in_phase_space_layout(out_psl), in_coords)
+    return in_moms, _build_momenta(proc, model, in_moms, out_psl, out_coords)
 end
 
 """
@@ -203,14 +105,11 @@ function build_momenta(
     out_psl::AbstractOutPhaseSpaceLayout,
     out_coords::NTuple{Nc,T},
 ) where {Nc,NIN,T}
-    return _build_momenta(
-        Val(phase_space_dimension(proc, model, out_psl)),
-        proc,
-        model,
-        in_moms,
-        out_psl,
-        out_coords,
+    _check_number_of_momenta(Val(number_incoming_particles(proc)), in_moms)
+    _check_phase_space_dimension(
+        Val(phase_space_dimension(proc, model, out_psl)), out_coords
     )
+    return _build_momenta(proc, model, in_moms, out_psl, out_coords)
 end
 
 function build_momenta(
@@ -220,13 +119,11 @@ function build_momenta(
     in_coords::NTuple{Ncin,T},
     out_coords::NTuple{Ncout,T},
 ) where {Ncin,Ncout,T}
-    return _build_momenta(
+    _check_phase_space_dimension(
         Val(phase_space_dimension(proc, model, in_phase_space_layout(out_psl))),
         Val(phase_space_dimension(proc, model, out_psl)),
-        proc,
-        model,
-        out_psl,
         in_coords,
         out_coords,
     )
+    return _build_momenta(proc, model, out_psl, in_coords, out_coords)
 end

--- a/src/implementations/phase_space_layout/build_momenta.jl
+++ b/src/implementations/phase_space_layout/build_momenta.jl
@@ -117,6 +117,65 @@ function _build_momenta(
     return _build_momenta(proc, model, in_moms, out_psl, out_coords)
 end
 
+function _build_momenta(
+    ::Val{Ncin},
+    ::Val{Ncout},
+    proc::AbstractProcessDefinition,
+    model::AbstractModelDefinition,
+    out_psl::AbstractOutPhaseSpaceLayout,
+    in_coords::NTuple{N1,T},
+    out_coords::NTuple{N2,T},
+) where {Ncin,Ncout,N1,N2,T<:Real}
+    err_msg = ""
+
+    if Ncin != N1
+        err_msg =
+            err_msg *
+            "number of in coordinates <$N1> must be the same as the in-phase-space dimension <$Ncin>\n"
+    end
+
+    if Ncout != N2
+        err_msg =
+            err_msg *
+            "number of out coordinates <$N2> must be the same as the out-phase-space dimension <$Ncout>"
+    end
+
+    throw(InvalidInputError(err_msg))
+end
+
+function _build_momenta(
+    ::Val{Ncin},
+    ::Val{Ncout},
+    proc::AbstractProcessDefinition,
+    model::AbstractModelDefinition,
+    out_psl::AbstractOutPhaseSpaceLayout,
+    in_coords::NTuple{Ncin,T},
+    out_coords::NTuple{Ncout,T},
+) where {Ncin,Ncout,T<:Real}
+    in_moms = _build_momenta(proc, model, in_phase_space_layout(out_psl), in_coords)
+    return _build_momenta(proc, model, in_moms, out_psl, out_coords)
+end
+
+# this only exists, since the constructor of `QEDcore.PhaseSpacePoint` calls it and not
+# build_momenta(...) without the underscore
+function _build_momenta(
+    proc::AbstractProcessDefinition,
+    model::AbstractModelDefinition,
+    out_psl::AbstractOutPhaseSpaceLayout,
+    in_coords::NTuple{Ncin,T},
+    out_coords::NTuple{Ncout,T},
+) where {Ncin,Ncout,T<:Real}
+    return _build_momenta(
+        Val(phase_space_dimension(proc, model, in_phase_space_layout(out_psl))),
+        Val(phase_space_dimension(proc, model, out_psl)),
+        proc,
+        model,
+        out_psl,
+        in_coords,
+        out_coords,
+    )
+end
+
 """
     build_momenta(proc, model, Ptot::AbstractFourMomentum, out_psl::AbstractOutPhaseSpaceLayout, out_coords::Tuple)
 
@@ -150,6 +209,24 @@ function build_momenta(
         model,
         in_moms,
         out_psl,
+        out_coords,
+    )
+end
+
+function build_momenta(
+    proc::AbstractProcessDefinition,
+    model::AbstractModelDefinition,
+    out_psl::AbstractOutPhaseSpaceLayout,
+    in_coords::NTuple{Ncin,T},
+    out_coords::NTuple{Ncout,T},
+) where {Ncin,Ncout,T}
+    return _build_momenta(
+        Val(phase_space_dimension(proc, model, in_phase_space_layout(out_psl))),
+        Val(phase_space_dimension(proc, model, out_psl)),
+        proc,
+        model,
+        out_psl,
+        in_coords,
         out_coords,
     )
 end

--- a/src/implementations/phase_space_layout/build_momenta.jl
+++ b/src/implementations/phase_space_layout/build_momenta.jl
@@ -153,7 +153,7 @@ function _build_momenta(
     out_coords::NTuple{Ncout,T},
 ) where {Ncin,Ncout,T<:Real}
     in_moms = _build_momenta(proc, model, in_phase_space_layout(out_psl), in_coords)
-    return _build_momenta(proc, model, in_moms, out_psl, out_coords)
+    return in_moms, _build_momenta(proc, model, in_moms, out_psl, out_coords)
 end
 
 # this only exists, since the constructor of `QEDcore.PhaseSpacePoint` calls it and not

--- a/src/implementations/phase_space_layout/checks.jl
+++ b/src/implementations/phase_space_layout/checks.jl
@@ -1,0 +1,43 @@
+_check_phase_space_dimension(::Val{N}, out_coords::NTuple{N}) where {N} = nothing
+function _check_phase_space_dimension(
+    ::Val{Nin}, ::Val{Nout}, in_coords::NTuple{Nin}, out_coords::NTuple{Nout}
+) where {Nin,Nout}
+    return nothing
+end
+
+function _check_phase_space_dimension(::Val{Nc}, out_coords::NTuple{N}) where {Nc,N}
+    throw(
+        InvalidInputError(
+            "number of coordinates <$N> must be the same as the out-phase-space dimension <$Nc>",
+        ),
+    )
+end
+
+function _check_phase_space_dimension(
+    ::Val{Ncin}, ::Val{Ncout}, in_coords::NTuple{N1}, out_coords::NTuple{N2}
+) where {Ncin,Ncout,N1,N2}
+    err_msg = ""
+
+    if Ncin != N1
+        err_msg =
+            err_msg *
+            "number of in coordinates <$N1> must be the same as the in-phase-space dimension <$Ncin>\n"
+    end
+
+    if Ncout != N2
+        err_msg =
+            err_msg *
+            "number of out coordinates <$N2> must be the same as the out-phase-space dimension <$Ncout>"
+    end
+
+    throw(InvalidInputError(err_msg))
+end
+
+_check_number_of_momenta(::Val{N}, moms::NTuple{N}) where {N} = nothing
+function _check_number_of_momenta(::Val{Nin}, moms::NTuple{N}) where {Nin,N}
+    throw(
+        InvalidInputError(
+            "number of in momenta <$N> must be the same as the number of incoming particles<$Nin>",
+        ),
+    )
+end

--- a/test/interfaces/phase_space_layout.jl
+++ b/test/interfaces/phase_space_layout.jl
@@ -27,6 +27,9 @@ RNG = MersenneTwister(137137)
         test_out_moms = @inferred build_momenta(
             TESTPROC, TESTMODEL, test_in_moms, TESTOUTPSL, TESTOUTCOORDS
         )
+        test_out_moms_from_coords = @inferred build_momenta(
+            TESTPROC, TESTMODEL, TESTOUTPSL, TESTINCOORDS, TESTOUTCOORDS
+        )
         groundtruth_out_moms = Mocks._groundtruth_out_moms(
             test_in_moms, TESTOUTCOORDS, MOM_TYPE
         )
@@ -40,11 +43,33 @@ RNG = MersenneTwister(137137)
             end
 
             @testset "out-phase-space layout" begin
-                @test length(test_out_moms) == N_OUTGOING
-                @test all(
-                    isapprox.(test_out_moms, groundtruth_out_moms, atol=ATOL, rtol=RTOL)
-                )
-                @test isapprox(sum(test_in_moms), sum(test_out_moms), atol=ATOL, rtol=RTOL)
+                @testset "in momenta based" begin
+                    @test length(test_out_moms) == N_OUTGOING
+                    @test all(
+                        isapprox.(test_out_moms, groundtruth_out_moms, atol=ATOL, rtol=RTOL)
+                    )
+                    @test isapprox(
+                        sum(test_in_moms), sum(test_out_moms), atol=ATOL, rtol=RTOL
+                    )
+                end
+
+                @testset "in coords based" begin
+                    @test length(test_out_moms_from_coords) == N_OUTGOING
+                    @test all(
+                        isapprox.(
+                            test_out_moms_from_coords,
+                            groundtruth_out_moms,
+                            atol=ATOL,
+                            rtol=RTOL,
+                        ),
+                    )
+                    @test isapprox(
+                        sum(test_in_moms),
+                        sum(test_out_moms_from_coords),
+                        atol=ATOL,
+                        rtol=RTOL,
+                    )
+                end
             end
 
             @testset "Error handling" begin
@@ -62,8 +87,24 @@ RNG = MersenneTwister(137137)
                 # "no coordinates" is already the lowest amount
                 if N_OUTGOING != 1
                     # not enough coordinates
+
                     @test_throws InvalidInputError build_momenta(
                         TESTPROC, TESTMODEL, test_in_moms, TESTOUTPSL, TESTOUTCOORDS[2:end]
+                    )
+                    @test_throws InvalidInputError build_momenta(
+                        TESTPROC, TESTMODEL, TESTOUTPSL, TESTINCOORDS, TESTOUTCOORDS[2:end]
+                    )
+
+                    @test_throws InvalidInputError build_momenta(
+                        TESTPROC, TESTMODEL, TESTOUTPSL, TESTINCOORDS[2:end], TESTOUTCOORDS
+                    )
+
+                    @test_throws InvalidInputError build_momenta(
+                        TESTPROC,
+                        TESTMODEL,
+                        TESTOUTPSL,
+                        TESTINCOORDS[2:end],
+                        TESTOUTCOORDS[2:end],
                     )
                 end
 
@@ -73,6 +114,22 @@ RNG = MersenneTwister(137137)
                     TESTMODEL,
                     test_in_moms,
                     TESTOUTPSL,
+                    (TESTOUTCOORDS..., rand(RNG)),
+                )
+
+                @test_throws InvalidInputError build_momenta(
+                    TESTPROC,
+                    TESTMODEL,
+                    TESTOUTPSL,
+                    (TESTINCOORDS..., rand(RNG)),
+                    TESTOUTCOORDS,
+                )
+
+                @test_throws InvalidInputError build_momenta(
+                    TESTPROC,
+                    TESTMODEL,
+                    TESTOUTPSL,
+                    (TESTINCOORDS..., rand(RNG)),
                     (TESTOUTCOORDS..., rand(RNG)),
                 )
             end

--- a/test/interfaces/phase_space_layout.jl
+++ b/test/interfaces/phase_space_layout.jl
@@ -27,7 +27,7 @@ RNG = MersenneTwister(137137)
         test_out_moms = @inferred build_momenta(
             TESTPROC, TESTMODEL, test_in_moms, TESTOUTPSL, TESTOUTCOORDS
         )
-        test_out_moms_from_coords = @inferred build_momenta(
+        test_in_moms_from_coords, test_out_moms_from_coords = @inferred build_momenta(
             TESTPROC, TESTMODEL, TESTOUTPSL, TESTINCOORDS, TESTOUTCOORDS
         )
         groundtruth_out_moms = Mocks._groundtruth_out_moms(
@@ -39,6 +39,11 @@ RNG = MersenneTwister(137137)
                 @test length(test_in_moms) == N_INCOMING
                 @test all(
                     isapprox.(test_in_moms, groundtruth_in_moms, atol=ATOL, rtol=RTOL)
+                )
+                @test all(
+                    isapprox.(
+                        test_in_moms_from_coords, groundtruth_in_moms, atol=ATOL, rtol=RTOL
+                    ),
                 )
             end
 

--- a/test/interfaces/phase_space_layout.jl
+++ b/test/interfaces/phase_space_layout.jl
@@ -8,7 +8,7 @@ RNG = MersenneTwister(137137)
     (1, rand(RNG, 2:8)), (1, rand(RNG, 2:8))
 )
     @testset "$MOM_EL_TYPE" for MOM_EL_TYPE in (Float16, Float32, Float64)
-        ATOL = 0.0
+        ATOL = eps(MOM_EL_TYPE)
         RTOL = sqrt(eps(MOM_EL_TYPE))
         MOM_TYPE = MockMomentum{MOM_EL_TYPE}
         INCOMING_PARTICLES = Tuple(rand(RNG, Mocks.PARTICLE_SET, N_INCOMING))
@@ -136,6 +136,15 @@ RNG = MersenneTwister(137137)
                     TESTOUTPSL,
                     (TESTINCOORDS..., rand(RNG)),
                     (TESTOUTCOORDS..., rand(RNG)),
+                )
+
+                # wrong number of in momenta
+                @test_throws InvalidInputError build_momenta(
+                    TESTPROC,
+                    TESTMODEL,
+                    (test_in_moms..., rand(RNG, MOM_TYPE)),
+                    TESTOUTPSL,
+                    TESTOUTCOORDS,
                 )
             end
         end


### PR DESCRIPTION
This PR extends the api of out-phase-space layouts by adding `_build_momenta` methods, which consume both in and out coordinates. For instance: 

```julia
_build_momenta(
    proc::AbstractProcessDefinition,
    model::AbstractModelDefinition,
    out_psl::AbstractOutPhaseSpaceLayout,
    in_coords::NTuple{Ncin,T},
    out_coords::NTuple{Ncout,T},
) where {Ncin,Ncout,T}
```

This might solve https://github.com/QEDjl-project/QEDcore.jl/issues/100 (resp. unittests in `QEDcore` are needed)

