### PR TITLE
Add type arguments to mass and charge functions

### DIFF
--- a/.formatting/format_all.jl
+++ b/.formatting/format_all.jl
@@ -1,6 +1,6 @@
 using JuliaFormatter
 
-# we asume the format_all.jl script is located in QEDbase.jl/.formatting
+# we assume the format_all.jl script is located in QEDbase.jl/.formatting
 project_path = Base.Filesystem.joinpath(Base.Filesystem.dirname(Base.source_path()), "..")
 
 not_formatted = format(project_path; verbose=true)

--- a/docs/src/tutorial/particle.jl
+++ b/docs/src/tutorial/particle.jl
@@ -30,8 +30,8 @@ QEDbase.is_anti_particle(::Muon) = false  # Muon is not an anti-particle
 # These functions return the mass and charge of the `Muon`.
 
 # Define the physical properties of the Muon
-QEDbase.mass(::Muon) = 105.66  # Muon mass in MeV/c^2
-QEDbase.charge(::Muon) = -1.0  # Muon has a charge of -1 (same as electron)
+QEDbase.mass(::Type{T}, ::Muon) where {T<:Number} = T(105.66)  # Muon mass in MeV/c^2
+QEDbase.charge(::Type{T}, ::Muon) where {T<:Number} = -one(T)  # Muon has a charge of -1 (same as electron)
 
 # ## Anti-Particle Implementation (Optional)
 #
@@ -48,8 +48,8 @@ QEDbase.is_particle(::AntiMuon) = false      # AntiMuon is not a regular particl
 QEDbase.is_anti_particle(::AntiMuon) = true  # AntiMuon is an anti-particle
 
 # Define the physical properties for the AntiMuon
-QEDbase.mass(::AntiMuon) = 105.66  # AntiMuon has the same mass as Muon
-QEDbase.charge(::AntiMuon) = 1.0   # AntiMuon has the opposite charge of Muon
+QEDbase.mass(::Type{T}, ::AntiMuon) where {T<:Number} = T(105.66)  # AntiMuon has the same mass as Muon
+QEDbase.charge(::Type{T}, ::AntiMuon) where {T<:Number} = one(T)   # AntiMuon has the opposite charge of Muon
 
 # ## Example Usage
 #
@@ -61,10 +61,10 @@ mu = Muon()
 anti_mu = AntiMuon()
 
 # Access particle properties
-println("Is Muon a fermion? ", is_fermion(mu))            # true
+println("Is Muon a fermion? ", is_fermion(mu))                        # true
 println("Is AntiMuon an anti-particle? ", is_anti_particle(anti_mu))  # true
-println("Muon mass: ", mass(mu), " MeV/c^2")              # 105.66 MeV/c^2
-println("AntiMuon charge: ", charge(anti_mu))             # +1.0
+println("Muon mass: ", mass(mu), " MeV/c^2")                          # 105.66 MeV/c^2
+println("AntiMuon charge: ", charge(anti_mu))                         # +1.0
 
 # ## Summary
 #

--- a/docs/src/tutorial/phase_space_point.jl
+++ b/docs/src/tutorial/phase_space_point.jl
@@ -22,8 +22,10 @@
 using QEDbase
 
 redirect_stdout(devnull) do # hide
-include(joinpath(dirname(Base.active_project()), "src", "tutorial", "particle.jl"))          # to get predefined particles
-include(joinpath(dirname(Base.active_project()), "src", "tutorial", "particle_stateful.jl")) # to get custom particle stateful definition
+    include(joinpath(dirname(Base.active_project()), "src", "tutorial", "particle.jl"))          # to get predefined particles
+    include(
+        joinpath(dirname(Base.active_project()), "src", "tutorial", "particle_stateful.jl")
+    ) # to get custom particle stateful definition
 end # hide
 
 # We'll also need a `Photon` type which we briefly define right here.
@@ -32,8 +34,8 @@ struct Photon <: AbstractParticleType end
 QEDbase.is_boson(::Photon) = true
 QEDbase.is_particle(::Photon) = true
 QEDbase.is_anti_particle(::Photon) = true
-QEDbase.mass(::Photon) = 0.0
-QEDbase.charge(::Photon) = 0.0
+QEDbase.mass(::Type{T}, ::Photon) where {T<:Number} = one(T)
+QEDbase.charge(::Type{T}, ::Photon) where {T<:Number} = one(T)
 
 # ## Step 1: Define an Example Process
 # We define a process that describes muon-anti-muon annihilation. This process will involve

--- a/src/QEDbase.jl
+++ b/src/QEDbase.jl
@@ -134,6 +134,7 @@ include("implementations/cross_section/total_probability.jl")
 include("implementations/cross_section/total_cross_section.jl")
 
 include("implementations/particle/print.jl")
+include("implementations/particle/properties.jl")
 
 include("implementations/particle_stateful/momentum.jl")
 include("implementations/phase_space_point/momenta.jl")

--- a/src/implementations/particle/properties.jl
+++ b/src/implementations/particle/properties.jl
@@ -1,0 +1,2 @@
+mass(p::AbstractParticle) = mass(Float64, p)
+charge(p::AbstractParticle) = charge(Float64, p)

--- a/src/interfaces/particle.jl
+++ b/src/interfaces/particle.jl
@@ -19,8 +19,8 @@ If the output of those functions differ from the defaults for a subtype of `Abst
 The second type of functions define a hard interface for `AbstractParticle`:
 
 ```julia
-    mass(::AbstractParticle)::Real
-    charge(::AbstractParticle)::Real
+    mass(::Type{T}, ::AbstractParticle)::T
+    charge(::Type{T}, ::AbstractParticle)::T
 ```
 These functions must be implemented in order to have the subtype of `AbstractParticle` work with the functionalities of `QEDprocesses.jl`.
 """
@@ -70,20 +70,22 @@ The default implementation of `is_anti_particle` for every subtype of [`Abstract
 is_anti_particle(::AbstractParticle) = false
 
 """
-    mass(particle::AbstractParticle)::Real
+    mass(::Type{T}, particle::AbstractParticle)::T
 
-Interface function for particles. Return the rest mass of a particle (in units of the electron mass).
+Interface function for particles. Return the rest mass of a particle (in units of the electron mass) in type `T`.
 
-This needs to be implemented for each concrete subtype of [`AbstractParticle`](@ref).
+This needs to be implemented for each concrete subtype of [`AbstractParticle`](@ref). A function `mass(p::AbstractParticle) = mass(Float64, p)` is
+automatically derived.
 """
 function mass end
 
 """
-    charge(::AbstractParticle)::Real
+    charge(::Type{T}, ::AbstractParticle)::T
 
-Interface function for particles. Return the electric charge of a particle (in units of the elementary electric charge).
+Interface function for particles. Return the electric charge of a particle (in units of the elementary electric charge) in type `T`.
 
-This needs to be implemented for each concrete subtype of [`AbstractParticle`](@ref).
+This needs to be implemented for each concrete subtype of [`AbstractParticle`](@ref). A function `charge(p::AbstractParticle) = charge(Float64, p)` is
+automatically derived.
 """
 function charge end
 
@@ -95,13 +97,13 @@ Compute the propagator of a particle for a given four-momentum `mom`.
 # Notes on Convention
 The `QEDProcesses.jl` package includes two types of propagators:
 
-**Boson-like particles**: For a `BosonLike` particle with four-momentum `k` and mass `m = QEDbase.mass(particle)`, the propagator is given by:
+**Boson-like particles**: For a `BosonLike` particle with four-momentum `k` and mass `m = QEDbase.mass(T, particle)`, the propagator is given by:
 
 ```math
 D(k) = \\frac{1}{k^2 - m^2}
 ```
 
-**Fermion-like particles**: For a `FermionLike` particle with four-momentum `p` and mass `m = QEDbase.mass(particle)`, the propagator is defined as:
+**Fermion-like particles**: For a `FermionLike` particle with four-momentum `p` and mass `m = QEDbase.mass(T, particle)`, the propagator is defined as:
 
 ```math
 S(p) = \\frac{\\gamma^\\mu p_\\mu + m}{p^2 - m^2}

--- a/src/interfaces/particle_stateful.jl
+++ b/src/interfaces/particle_stateful.jl
@@ -46,5 +46,7 @@ function momentum end
     is_particle(particle_species(particle))
 @inline is_anti_particle(particle::AbstractParticleStateful) =
     is_anti_particle(particle_species(particle))
-@inline mass(particle::AbstractParticleStateful) = mass(particle_species(particle))
-@inline charge(particle::AbstractParticleStateful) = charge(particle_species(particle))
+@inline mass(::Type{T}, particle::AbstractParticleStateful) where {T<:Number} =
+    mass(T, particle_species(particle))
+@inline charge(::Type{T}, particle::AbstractParticleStateful) where {T<:Number} =
+    charge(T, particle_species(particle))

--- a/src/mocks/particles/test_impl.jl
+++ b/src/mocks/particles/test_impl.jl
@@ -4,8 +4,8 @@ QEDbase.is_fermion(::MockFermion) = true
 QEDbase.is_boson(::MockFermion) = false
 QEDbase.is_particle(::MockFermion) = true
 QEDbase.is_anti_particle(::MockFermion) = false
-QEDbase.mass(::MockFermion) = _MASS_TEST_FERMION
-QEDbase.charge(::MockFermion) = _CHARGE_TEST_FERMION
+QEDbase.mass(::Type{T}, ::MockFermion) where {T<:Number} = T(_MASS_TEST_FERMION)
+QEDbase.charge(::Type{T}, ::MockFermion) where {T<:Number} = T(_CHARGE_TEST_FERMION)
 function QEDbase.propagator(::MockFermion, mom::AbstractMockMomentum)
     return _groundtruth_fermion_propagator(mom)
 end
@@ -23,8 +23,8 @@ QEDbase.is_fermion(::MockMasslessFermion) = true
 QEDbase.is_boson(::MockMasslessFermion) = false
 QEDbase.is_particle(::MockMasslessFermion) = true
 QEDbase.is_anti_particle(::MockMasslessFermion) = false
-QEDbase.mass(::MockMasslessFermion) = 0.0
-QEDbase.charge(::MockMasslessFermion) = _CHARGE_TEST_FERMION
+QEDbase.mass(::Type{T}, ::MockMasslessFermion) where {T<:Number} = zero(T)
+QEDbase.charge(::Type{T}, ::MockMasslessFermion) where {T<:Number} = T(_CHARGE_TEST_FERMION)
 function QEDbase.propagator(::MockMasslessFermion, mom::AbstractMockMomentum)
     return _groundtruth_fermion_propagator(mom)
 end
@@ -42,8 +42,8 @@ QEDbase.is_fermion(::MockBoson) = false
 QEDbase.is_boson(::MockBoson) = true
 QEDbase.is_particle(::MockBoson) = true
 QEDbase.is_anti_particle(::MockBoson) = false
-QEDbase.mass(::MockBoson) = _MASS_TEST_BOSON
-QEDbase.charge(::MockBoson) = _CHARGE_TEST_BOSON
+QEDbase.mass(::Type{T}, ::MockBoson) where {T<:Number} = T(_MASS_TEST_BOSON)
+QEDbase.charge(::Type{T}, ::MockBoson) where {T<:Number} = T(_CHARGE_TEST_BOSON)
 function QEDbase.propagator(::MockBoson, mom::AbstractMockMomentum)
     return _groundtruth_boson_propagator(mom)
 end
@@ -61,8 +61,8 @@ QEDbase.is_fermion(::MockMasslessBoson) = false
 QEDbase.is_boson(::MockMasslessBoson) = true
 QEDbase.is_particle(::MockMasslessBoson) = true
 QEDbase.is_anti_particle(::MockMasslessBoson) = false
-QEDbase.mass(::MockMasslessBoson) = 0.0
-QEDbase.charge(::MockMasslessBoson) = _CHARGE_TEST_BOSON
+QEDbase.mass(::Type{T}, ::MockMasslessBoson) where {T<:Number} = zero(T)
+QEDbase.charge(::Type{T}, ::MockMasslessBoson) where {T<:Number} = T(_CHARGE_TEST_BOSON)
 function QEDbase.propagator(::MockMasslessBoson, mom::AbstractMockMomentum)
     return _groundtruth_boson_propagator(mom)
 end

--- a/test/interfaces/particles.jl
+++ b/test/interfaces/particles.jl
@@ -38,18 +38,45 @@ BUF = IOBuffer()
         @test is_boson(MockMasslessBoson()) == true
     end
 
-    @testset "mass" begin
-        @test mass(MockFermion()) == Mocks._MASS_TEST_FERMION
-        @test mass(MockMasslessFermion()) == 0.0
-        @test mass(MockBoson()) == Mocks._MASS_TEST_BOSON
-        @test mass(MockMasslessBoson()) == 0.0
+    @testset "mass & charge in $FLOAT_T" for FLOAT_T in (Float16, Float32, Float64)
+        @testset "mass" begin
+            @test mass(FLOAT_T, MockFermion()) == FLOAT_T(Mocks._MASS_TEST_FERMION)
+            @test mass(FLOAT_T, MockMasslessFermion()) == zero(FLOAT_T)
+            @test mass(FLOAT_T, MockBoson()) == FLOAT_T(Mocks._MASS_TEST_BOSON)
+            @test mass(FLOAT_T, MockMasslessBoson()) == zero(FLOAT_T)
+
+            @test mass(FLOAT_T, MockFermion()) isa FLOAT_T
+            @test mass(FLOAT_T, MockMasslessFermion()) isa FLOAT_T
+            @test mass(FLOAT_T, MockBoson()) isa FLOAT_T
+            @test mass(FLOAT_T, MockMasslessBoson()) isa FLOAT_T
+        end
+
+        @testset "charge" begin
+            @test charge(FLOAT_T, MockFermion()) == FLOAT_T(Mocks._CHARGE_TEST_FERMION)
+            @test charge(FLOAT_T, MockMasslessFermion()) ==
+                FLOAT_T(Mocks._CHARGE_TEST_FERMION)
+            @test charge(FLOAT_T, MockBoson()) == FLOAT_T(Mocks._CHARGE_TEST_BOSON)
+            @test charge(FLOAT_T, MockMasslessBoson()) == FLOAT_T(Mocks._CHARGE_TEST_BOSON)
+
+            @test charge(FLOAT_T, MockFermion()) isa FLOAT_T
+            @test charge(FLOAT_T, MockMasslessFermion()) isa FLOAT_T
+            @test charge(FLOAT_T, MockBoson()) isa FLOAT_T
+            @test charge(FLOAT_T, MockMasslessBoson()) isa FLOAT_T
+        end
     end
 
-    @testset "charge" begin
-        @test charge(MockFermion()) == Mocks._CHARGE_TEST_FERMION
-        @test charge(MockMasslessFermion()) == Mocks._CHARGE_TEST_FERMION
-        @test charge(MockBoson()) == Mocks._CHARGE_TEST_BOSON
-        @test charge(MockMasslessBoson()) == Mocks._CHARGE_TEST_BOSON
+    @testset "mass default type" begin
+        @test mass(MockFermion()) isa Float64
+        @test mass(MockMasslessFermion()) isa Float64
+        @test mass(MockBoson()) isa Float64
+        @test mass(MockMasslessBoson()) isa Float64
+    end
+
+    @testset "charge default type" begin
+        @test charge(MockFermion()) isa Float64
+        @test charge(MockMasslessFermion()) isa Float64
+        @test charge(MockBoson()) isa Float64
+        @test charge(MockMasslessBoson()) isa Float64
     end
 
     @testset "show" begin


### PR DESCRIPTION
Both functions now default to `Float64`, but can take a first argument of a requested type to return.