### PR TITLE
Add a Val() overload for the momentum interface

### DIFF
--- a/src/implementations/phase_space_point/momenta.jl
+++ b/src/implementations/phase_space_point/momenta.jl
@@ -1,10 +1,16 @@
 """
     momentum(psp::AbstractPhaseSpacePoint, dir::ParticleDirection, n::Int)
+    momentum(psp::AbstractPhaseSpacePoint, dir::ParticleDirection, ::Val{N}) where {N}
 
 Returns the momentum of the `n`th particle in the given [`AbstractPhaseSpacePoint`](@ref) which has direction `dir`. If `n` is outside the valid range for this phase space point, a `BoundsError` is thrown.
 """
 function momentum(psp::AbstractPhaseSpacePoint, dir::ParticleDirection, n::Int)
     return momentum(psp[dir, n])
+end
+function momentum(psp::AbstractPhaseSpacePoint, dir::ParticleDirection, ::Val{N}) where {N}
+    @assert N > 0 "requested $dir particle $N of process $(process(psp)), but N must be at least 1"
+    @assert N <= number_particles(process(psp), dir) "requested $dir particle $N of process $(process(psp)), but only $(number_particles(process(psp), dir)) are available"
+    return @inbounds momenta(psp, dir)[N]
 end
 
 function _momentum_helper(particles::Tuple{}, species::SPECIES, n::Val{N}) where {SPECIES, N}

--- a/src/interfaces/four_momentum.jl
+++ b/src/interfaces/four_momentum.jl
@@ -3,7 +3,7 @@
 
 Abstract base type for four-momentas, representing one energy and three spacial components.
 
-Also see: [`QEDcore.SFourMomentum`](@extref), [`QEDcore.MFourMomentum`](@extref)
+Also see: [`QEDcore.SFourMomentum`](@extref)
 """
 abstract type AbstractFourMomentum{T_ELEM <: Real} <: AbstractLorentzVector{T_ELEM} end
 

--- a/test/interfaces/phase_space_point.jl
+++ b/test/interfaces/phase_space_point.jl
@@ -28,6 +28,20 @@ RNG = MersenneTwister(137137)
         end
 
         @testset "momentum implementations" begin
+            @test @inferred momentum(PSP, Incoming(), 1) == IN_PS[1]
+            @test @inferred momentum(PSP, Incoming(), 2) == IN_PS[2]
+            @test @inferred momentum(PSP, Incoming(), 3) == IN_PS[3]
+            @test @inferred momentum(PSP, Outgoing(), 1) == OUT_PS[1]
+            @test @inferred momentum(PSP, Outgoing(), 2) == OUT_PS[2]
+            @test @inferred momentum(PSP, Outgoing(), 3) == OUT_PS[3]
+
+            @test @inferred momentum(PSP, Incoming(), Val(1)) == IN_PS[1]
+            @test @inferred momentum(PSP, Incoming(), Val(2)) == IN_PS[2]
+            @test @inferred momentum(PSP, Incoming(), Val(3)) == IN_PS[3]
+            @test @inferred momentum(PSP, Outgoing(), Val(1)) == OUT_PS[1]
+            @test @inferred momentum(PSP, Outgoing(), Val(2)) == OUT_PS[2]
+            @test @inferred momentum(PSP, Outgoing(), Val(3)) == OUT_PS[3]
+
             @test @inferred momentum(PSP, Incoming(), MockBoson(), 1) == IN_PS[1]
             @test @inferred momentum(PSP, Incoming(), MockFermion(), 1) == IN_PS[2]
             @test @inferred momentum(PSP, Incoming(), MockFermion()) == IN_PS[2]
@@ -64,6 +78,10 @@ RNG = MersenneTwister(137137)
             @test_throws InvalidInputError momentum(PSP, Outgoing(), MockFermion())
 
             # same for Val() overloads
+            @test_throws AssertionError momentum(PSP, Incoming(), Val(0))
+            @test_throws AssertionError momentum(PSP, Outgoing(), Val(0))
+            @test_throws AssertionError momentum(PSP, Incoming(), Val(4))
+            @test_throws AssertionError momentum(PSP, Outgoing(), Val(4))
             @test_throws BoundsError momentum(PSP, Incoming(), MockBoson(), Val(0))
             @test_throws BoundsError momentum(PSP, Outgoing(), MockFermion(), Val(0))
             @test_throws BoundsError momentum(PSP, Incoming(), MockFermion(), Val(2))


### PR DESCRIPTION
This interface was missing. If there are more overload versions that are still missing we can add them here too.