### PR TITLE
Improve precision of four momentum interface

### DIFF
--- a/src/interfaces/lorentz_vectors/arithmetic.jl
+++ b/src/interfaces/lorentz_vectors/arithmetic.jl
@@ -31,7 +31,7 @@ Return the Minkowski dot product of two `LorentzVectorLike`.
     ) where {T1, T2; IsLorentzVectorLike{T1}, IsLorentzVectorLike{T2}}
     # use a precise sum here because in many applications
     # the result will be close to zero
-    return _precise_sum(
+    return sum(
         (
             getT(x1) * getT(x2),
             -getX(x1) * getX(x2),

--- a/src/interfaces/lorentz_vectors/arithmetic.jl
+++ b/src/interfaces/lorentz_vectors/arithmetic.jl
@@ -32,7 +32,6 @@ Return the Minkowski dot product of two `LorentzVectorLike`.
     # use a precise sum here because in many applications
     # the result will be close to zero
     return _precise_sum(
-        eltype(x1),
         (
             getT(x1) * getT(x2),
             -getX(x1) * getX(x2),

--- a/src/interfaces/lorentz_vectors/arithmetic.jl
+++ b/src/interfaces/lorentz_vectors/arithmetic.jl
@@ -29,8 +29,17 @@ Return the Minkowski dot product of two `LorentzVectorLike`.
 @inline @traitfn function minkowski_dot(
         x1::T1, x2::T2
     ) where {T1, T2; IsLorentzVectorLike{T1}, IsLorentzVectorLike{T2}}
-    return getT(x1) * getT(x2) -
-        (getX(x1) * getX(x2) + getY(x1) * getY(x2) + getZ(x1) * getZ(x2))
+    # use a precise sum here because in many applications
+    # the result will be close to zero
+    return _precise_sum(
+        eltype(x1),
+        (
+            getT(x1) * getT(x2),
+            -getX(x1) * getX(x2),
+            -getY(x1) * getY(x2),
+            -getZ(x1) * getZ(x2),
+        )
+    )
 end
 
 """

--- a/src/interfaces/lorentz_vectors/arithmetic.jl
+++ b/src/interfaces/lorentz_vectors/arithmetic.jl
@@ -62,7 +62,7 @@ Return the square of the magnitude of a given `LorentzVectorLike`, i.e. the sum 
 
 """
 @inline @traitfn function getMagnitude2(lv::T) where {{T; IsLorentzVectorLike{T}}}
-    return getX(lv)^2 + getY(lv)^2 + getZ(lv)^2
+    return hypot(getX(lv), getY(lv), getZ(lv))^2
 end
 
 """
@@ -86,7 +86,7 @@ Return the magnitude of a given `LorentzVectorLike`, i.e. the euklidian norm spa
 
 """
 @inline @traitfn function getMagnitude(lv::T) where {{T; IsLorentzVectorLike{T}}}
-    return sqrt(getMagnitude2(lv))
+    return hypot(getX(lv), getY(lv), getZ(lv))
 end
 
 """
@@ -106,7 +106,7 @@ Return the squared invariant mass of a given `LorentzVectorLike`, i.e. the minko
 
 """
 @inline @traitfn function getInvariantMass2(lv::T) where {{T; IsLorentzVectorLike{T}}}
-    return minkowski_dot(lv, lv)
+    return getT(lv)^2 - hypot(getX(lv), getY(lv), getZ(lv))^2
 end
 
 """Function alias for [`getInvariantMass2`](@ref)"""
@@ -277,7 +277,7 @@ Return the transverse momentum for a given `LorentzVectorLike`, i.e. the magnitu
 
 """
 @inline @traitfn function getTransverseMomentum(lv::T) where {{T; IsLorentzVectorLike{T}}}
-    return sqrt(getTransverseMomentum2(lv))
+    return hypot(getX(lv), getY(lv))
 end
 """Function alias for [`getTransverseMomentum`](@ref)."""
 const getPt = getTransverseMomentum

--- a/src/interfaces/lorentz_vectors/arithmetic.jl
+++ b/src/interfaces/lorentz_vectors/arithmetic.jl
@@ -1,9 +1,7 @@
-import Base: *
-
 function dot(p1::T1, p2::T2) where {T1 <: AbstractLorentzVector, T2 <: AbstractLorentzVector}
     return mdot(p1, p2)
 end
-@inline function *(
+@inline function Base.:*(
         p1::T1, p2::T2
     ) where {T1 <: AbstractLorentzVector, T2 <: AbstractLorentzVector}
     return dot(p1, p2)

--- a/src/interfaces/lorentz_vectors/utility.jl
+++ b/src/interfaces/lorentz_vectors/utility.jl
@@ -7,7 +7,9 @@
 function isonshell(mom::QEDbase.AbstractLorentzVector{T}) where {T <: Real}
     mag2 = getMag2(mom)
     E = getE(mom)
-    return isapprox(E^2, mag2; rtol = 8 * eps(T))
+
+    # See https://github.com/QEDjl-project/QEDcore.jl/issues/22
+    return isapprox(E^2, mag2; rtol = sqrt(eps(T)))
 end
 
 """
@@ -27,7 +29,9 @@ function isonshell(mom::QEDbase.AbstractLorentzVector{T}, mass::Real) where {T <
     end
     mag2 = getMag2(mom)
     E = getE(mom)
-    return isapprox(E^2, (mass)^2 + mag2; atol = 8 * eps(T), rtol = 8 * eps(T))
+
+    # see https://github.com/QEDjl-project/QEDcore.jl/issues/22
+    return isapprox(E^2, (mass)^2 + mag2; rtol = sqrt(eps(T)))
 end
 
 """

--- a/src/interfaces/lorentz_vectors/utility.jl
+++ b/src/interfaces/lorentz_vectors/utility.jl
@@ -7,7 +7,7 @@
 function isonshell(mom::QEDbase.AbstractLorentzVector{T}) where {T <: Real}
     mag2 = getMag2(mom)
     E = getE(mom)
-    return isapprox(E^2, mag2; rtol = eps(T))
+    return isapprox(E^2, mag2; rtol = 8 * eps(T))
 end
 
 """
@@ -27,7 +27,7 @@ function isonshell(mom::QEDbase.AbstractLorentzVector{T}, mass::Real) where {T <
     end
     mag2 = getMag2(mom)
     E = getE(mom)
-    return isapprox(E^2, (mass)^2 + mag2; atol = 2 * eps(T), rtol = eps(T))
+    return isapprox(E^2, (mass)^2 + mag2; atol = 8 * eps(T), rtol = 8 * eps(T))
 end
 
 """

--- a/src/interfaces/lorentz_vectors/utility.jl
+++ b/src/interfaces/lorentz_vectors/utility.jl
@@ -5,11 +5,7 @@
 #######
 
 function isonshell(mom::QEDbase.AbstractLorentzVector{T}) where {T <: Real}
-    mag2 = getMag2(mom)
-    E = getE(mom)
-
-    # See https://github.com/QEDjl-project/QEDcore.jl/issues/22
-    return isapprox(E^2, mag2; rtol = sqrt(eps(T)))
+    return isapprox(getE(mom), getMag(mom); rtol = 8 * eps(T))
 end
 
 """
@@ -27,11 +23,8 @@ function isonshell(mom::QEDbase.AbstractLorentzVector{T}, mass::Real) where {T <
     if iszero(mass)
         return isonshell(mom)
     end
-    mag2 = getMag2(mom)
-    E = getE(mom)
 
-    # see https://github.com/QEDjl-project/QEDcore.jl/issues/22
-    return isapprox(E^2, (mass)^2 + mag2; rtol = sqrt(eps(T)))
+    return isapprox(getE(mom), hypot(mass, getX(mom), getY(mom), getZ(mom)); rtol = 8 * eps(T))
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,27 +21,3 @@ Return a split of the given string delimited at the upper case letters in the st
 @inline function _split_uppercase(s::AbstractString)
     return split(s, r"(?=[A-Z])")
 end
-
-@inline _precise_sum_helper(in::Tuple{}, sum::T, error::T) where {T} = sum + error
-@inline function _precise_sum_helper(in::Tuple{T, Vararg{T, N}}, sum::T, error::T) where {N, T}
-    y = in[1] - error
-    t = sum + y
-    z = t - sum
-    error = z - y
-    sum = t
-
-    return _precise_sum_helper(in[2:end], sum, error)
-end
-
-
-"""
-    _precise_sum(in::NTuple{N, T})
-
-Calculate the sum of the values in a tuple, with error correction applied (using a simple unrolled Kahan summation algorithm).
-
-!!! note
-    This relies on fast-math optimizations being turned off.
-"""
-@inline function _precise_sum(in::NTuple{N, T}) where {N, T}
-    return _precise_sum_helper(in, zero(T), zero(T))
-end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,7 +23,7 @@ Return a split of the given string delimited at the upper case letters in the st
 end
 
 @inline _precise_sum_helper(in::Tuple{}, sum::T, error::T) where {T} = sum + error
-@inline function _precise_sum_helper(in::Tuple{T, Vararg{T, N}}, sum::T, error::T) where {N, T <: Number}
+@inline function _precise_sum_helper(in::Tuple{T, Vararg{T, N}}, sum::T, error::T) where {N, T}
     y = in[1] - error
     t = sum + y
     z = t - sum

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -22,21 +22,26 @@ Return a split of the given string delimited at the upper case letters in the st
     return split(s, r"(?=[A-Z])")
 end
 
-"""
-    _precise_sum(::Type{T}, in::NTuple{N, T})
-
-Calculate the sum of the values in a tuple, with error correction applied (using a simple unrolled Kahan summation algorithm).
-
-!!! note
-    This relies on fast-math optimizations being turned off.
-"""
-@inline _precise_sum(::Type{T}, in::Tuple{}; sum = zero(T), error = zero(T)) where {T} = sum + error
-@inline function _precise_sum(::Type{T}, in::Tuple{T, Vararg{T, N}}; sum = zero(T), error = zero(T)) where {N, T <: Number}
+@inline _precise_sum_helper(in::Tuple{}, sum::T, error::T) where {T} = sum + error
+@inline function _precise_sum_helper(in::Tuple{T, Vararg{T, N}}, sum::T, error::T) where {N, T <: Number}
     y = in[1] - error
     t = sum + y
     z = t - sum
     error = z - y
     sum = t
 
-    return _precise_sum(T, in[2:end]; sum = sum, error = error)
+    return _precise_sum_helper(in[2:end], sum, error)
+end
+
+
+"""
+    _precise_sum(in::NTuple{N, T})
+
+Calculate the sum of the values in a tuple, with error correction applied (using a simple unrolled Kahan summation algorithm).
+
+!!! note
+    This relies on fast-math optimizations being turned off.
+"""
+@inline function _precise_sum(in::NTuple{N, T}) where {N, T}
+    return _precise_sum_helper(in, zero(T), zero(T))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,3 +21,22 @@ Return a split of the given string delimited at the upper case letters in the st
 @inline function _split_uppercase(s::AbstractString)
     return split(s, r"(?=[A-Z])")
 end
+
+"""
+    _precise_sum(::Type{T}, in::NTuple{N, T})
+
+Calculate the sum of the values in a tuple, with error correction applied (using a simple unrolled Kahan summation algorithm).
+
+!!! note
+    This relies on fast-math optimizations being turned off.
+"""
+@inline _precise_sum(::Type{T}, in::Tuple{}; sum = zero(T), error = zero(T)) where {T} = sum + error
+@inline function _precise_sum(::Type{T}, in::Tuple{T, Vararg{T, N}}; sum = zero(T), error = zero(T)) where {N, T <: Number}
+    y = in[1] - error
+    t = sum + y
+    z = t - sum
+    error = z - y
+    sum = t
+
+    return _precise_sum(T, in[2:end]; sum = sum, error = error)
+end


### PR DESCRIPTION
I added a small implementation of the Kahan summation algorithm to fix precision problems in the minkowski product.
It's recursive and inlined over tuples, so it should unroll automatically.
The precision problem became noticeable in https://github.com/QEDjl-project/QEDcore.jl/pull/111. I hope this fixes this, unless CUDA compiles the precision away.

See https://en.wikipedia.org/wiki/Kahan_summation_algorithm