### PR TITLE
Use script/bootloader.jl

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,26 +6,28 @@ generate_pipeline:
   image: julia:1.10
   stage: generate
   variables:
-    CI_GIT_CI_TOOLS_URL: https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git
-    CI_GIT_CI_TOOLS_BRANCH: dev
-    CI_ENABLE_CUDA_TESTS: "ON"
-    CI_ENABLE_AMDGPU_TESTS: "ON"
+    CI_QED_GIT_CI_TOOLS_URL: https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git
+    CI_QED_GIT_CI_TOOLS_BRANCH: dev
+    CI_QED_ENABLE_CUDA_TESTS: "ON"
+    CI_QED_ENABLE_AMDGPU_TESTS: "ON"
   script:
     - apt update && apt install -y git
-    - git clone --depth 1 -b $CI_GIT_CI_TOOLS_BRANCH $CI_GIT_CI_TOOLS_URL /generator
+    - git clone --depth 1 -b $CI_QED_GIT_CI_TOOLS_BRANCH $CI_QED_GIT_CI_TOOLS_URL /generator
     - julia --project=/generator/.ci/CI -e 'import Pkg; Pkg.instantiate()'
-    - julia --project=/generator/.ci/CI /generator/.ci/CI/src/Bootloader.jl
+    - $(julia --project=/generator/.ci/CI /generator/.ci/CI/script/get_gitlab_ci_conf.jl)
+    - env | grep CI_QED_
+    - julia --project=/generator/.ci/CI /generator/.ci/CI/script/bootloader.jl
       --output-cpu=cpu_pipeline.yaml
       --output-gpu=gpu_pipeline.yaml
-      --output-unit-test-verify=unit_verify.yaml
+      --output-verify=verify.yaml
     - cat $CI_PROJECT_DIR/cpu_pipeline.yaml
     - cat $CI_PROJECT_DIR/gpu_pipeline.yaml
-    - cat $CI_PROJECT_DIR/unit_verify.yaml
+    - cat $CI_PROJECT_DIR/verify.yaml
   artifacts:
     paths:
       - cpu_pipeline.yaml
       - gpu_pipeline.yaml
-      - unit_verify.yaml
+      - verify.yaml
     expire_in: 1 week
   interruptible: true
   tags:
@@ -47,10 +49,10 @@ gpu_tests:
         job: generate_pipeline
     strategy: depend
 
-verify_unit_test_env_vars:
+verify_test_environment:
   stage: run
   trigger:
     include:
-      - artifact: unit_verify.yaml
+      - artifact: verify.yaml
         job: generate_pipeline
     strategy: depend


### PR DESCRIPTION
At the moment, it uses a feature branch of `bootloader.jl`. When PR https://github.com/QEDjl-project/QuantumElectrodynamics.jl/pull/135 is merged, I remove the latest commit and change the PR to non draft.  