### PR TITLE
Momentum accessor

### DIFF
--- a/docs/src/library/phase_space.md
+++ b/docs/src/library/phase_space.md
@@ -34,7 +34,8 @@ phase_space_layout
 ```@docs
 particle_direction
 particle_species
-momenta
+momenta(::AbstractPhaseSpacePoint, ::ParticleDirection)
+momenta(::AbstractPhaseSpacePoint)
 momentum_type(::AbstractPhaseSpacePoint)
 momentum_type(::Type{<:AbstractPhaseSpacePoint{P,M,L,PS}}) where {P,M,L,PS}
 momentum_eltype(::AbstractPhaseSpacePoint)

--- a/src/implementations/phase_space_point/momenta.jl
+++ b/src/implementations/phase_space_point/momenta.jl
@@ -124,6 +124,8 @@ function momenta(psp::AbstractPhaseSpacePoint, dir::ParticleDirection)
     return ntuple(i -> momentum(psp[dir, i]), number_particles(process(psp), dir))
 end
 
+momenta(psp::AbstractPhaseSpacePoint) = (momenta(psp, Incoming())..., momenta(psp, Outgoing())...)
+
 """
     momentum_type(psp::Type{AbstractPhaseSpacePoint})
 

--- a/src/implementations/phase_space_point/momenta.jl
+++ b/src/implementations/phase_space_point/momenta.jl
@@ -124,7 +124,14 @@ function momenta(psp::AbstractPhaseSpacePoint, dir::ParticleDirection)
     return ntuple(i -> momentum(psp[dir, i]), number_particles(process(psp), dir))
 end
 
-momenta(psp::AbstractPhaseSpacePoint) = (momenta(psp, Incoming())..., momenta(psp, Outgoing())...)
+"""
+    momenta(psp::AbstractPhaseSpacePoint)
+
+Return a `Tuple` containing all momenta, with incoming momenta listed before outgoing ones.
+"""
+function momenta(psp::AbstractPhaseSpacePoint)
+    return (momenta(psp, Incoming())..., momenta(psp, Outgoing())...)
+end
 
 """
     momentum_type(psp::Type{AbstractPhaseSpacePoint})

--- a/test/interfaces/phase_space_point.jl
+++ b/test/interfaces/phase_space_point.jl
@@ -93,6 +93,8 @@ RNG = MersenneTwister(137137)
         @testset "momenta implementation" begin
             @test IN_PS == @inferred momenta(PSP, Incoming())
             @test OUT_PS == @inferred momenta(PSP, Outgoing())
+            @test @inferred momenta(PSP) == (IN_PS..., OUT_PS...)
         end
+
     end
 end


### PR DESCRIPTION
This adds the convenience function

```Julia
momenta(psp::AbstractPhaseSpacePoint)
```

which returns all incoming particles' momenta, followed by the momenta of the outgoing particles, in a single tuple. 