### PR TITLE
Fixed accidental type cast

### DIFF
--- a/src/interfaces/lorentz_vectors/arithmetic.jl
+++ b/src/interfaces/lorentz_vectors/arithmetic.jl
@@ -350,7 +350,7 @@ Return the [rapidity](https://en.wikipedia.org/wiki/Rapidity) for a given `Loren
 
 """
 @inline @traitfn function getRapidity(lv::T) where {{T; IsLorentzVectorLike{T}}}
-    return 0.5 * log((getT(lv) + getZ(lv)) / (getT(lv) - getZ(lv)))
+    return log((getT(lv) + getZ(lv)) / (getT(lv) - getZ(lv))) / 2
 end
 
 #######################
@@ -472,7 +472,7 @@ Return the plus component for a given `LorentzVectorLike` in [light-cone coordin
 
 """
 @inline @traitfn function getPlus(lv::T) where {{T; IsLorentzVectorLike{T}}}
-    return 0.5 * (getT(lv) + getZ(lv))
+    return (getT(lv) + getZ(lv)) / 2
 end
 
 """
@@ -494,7 +494,7 @@ Return the minus component for a given `LorentzVectorLike` in [light-cone coordi
 
 """
 @inline @traitfn function getMinus(lv::T) where {{T; IsLorentzVectorLike{T}}}
-    return 0.5 * (getT(lv) - getZ(lv))
+    return (getT(lv) - getZ(lv)) / 2
 end
 
 ####

--- a/test/interfaces/momentum.jl
+++ b/test/interfaces/momentum.jl
@@ -1,5 +1,6 @@
 using QEDbase
 using QEDbase.Mocks
+using Random
 
 lorentz_getter = [
     getT,
@@ -78,3 +79,84 @@ lorentz_setter = [
         end
     end
 end # LorentzVectorInterface
+
+RNG = Xoshiro(161)
+DTYPES = (Float16, Float32, Float64)
+
+@testset "accessors" begin
+    @testset "$dtype" for dtype in DTYPES
+        X, Y, Z = rand(RNG, dtype, 3)
+        M = rand(RNG, dtype)
+        E = sqrt(X^2 + Y^2 + Z^2 + M^2) # ensure timelike coordinates
+
+
+        TEST_MOM = MockMomentum(E, X, Y, Z)
+
+        @testset "mass" begin
+            @test isapprox(getInvariantMass2(TEST_MOM), E^2 - X^2 - Y^2 - Z^2)
+            @test isapprox(getMass2(TEST_MOM), E^2 - X^2 - Y^2 - Z^2)
+            @test isapprox(getInvariantMass(TEST_MOM), sqrt(E^2 - X^2 - Y^2 - Z^2))
+            @test isapprox(getMass(TEST_MOM), sqrt(E^2 - X^2 - Y^2 - Z^2))
+        end
+
+        @testset "cartesian" begin
+            @test isapprox(getT(TEST_MOM), E)
+            @test isapprox(getX(TEST_MOM), X)
+            @test isapprox(getY(TEST_MOM), Y)
+            @test isapprox(getZ(TEST_MOM), Z)
+
+            @test isapprox(getE(TEST_MOM), E)
+            @test isapprox(getEnergy(TEST_MOM), E)
+            @test isapprox(getPx(TEST_MOM), X)
+            @test isapprox(getPy(TEST_MOM), Y)
+            @test isapprox(getPz(TEST_MOM), Z)
+        end
+
+        @testset "lorentz factors" begin
+            @test isapprox(getBeta(TEST_MOM), sqrt(X^2 + Y^2 + Z^2) / E)
+            @test isapprox(getGamma(TEST_MOM), E / M)
+        end
+
+        @testset "spherical" begin
+            @test isapprox(getMagnitude2(TEST_MOM), X^2 + Y^2 + Z^2)
+            @test isapprox(getMag2(TEST_MOM), X^2 + Y^2 + Z^2)
+            @test isapprox(getRho2(TEST_MOM), X^2 + Y^2 + Z^2)
+            @test isapprox(getMagnitude(TEST_MOM), sqrt(X^2 + Y^2 + Z^2))
+            @test isapprox(getMag(TEST_MOM), sqrt(X^2 + Y^2 + Z^2))
+            @test isapprox(getRho(TEST_MOM), sqrt(X^2 + Y^2 + Z^2))
+
+            @test isapprox(getTheta(TEST_MOM), atan(sqrt(X^2 + Y^2), Z))
+            @test isapprox(getCosTheta(TEST_MOM), Z / sqrt(X^2 + Y^2 + Z^2))
+            @test isapprox(getPhi(TEST_MOM), atan(Y, X))
+            @test isapprox(getCosPhi(TEST_MOM), X / sqrt(X^2 + Y^2))
+            @test isapprox(getSinPhi(TEST_MOM), Y / sqrt(X^2 + Y^2))
+        end
+
+        @testset "transverse" begin
+            @test isapprox(getTransverseMomentum2(TEST_MOM), X^2 + Y^2)
+            @test isapprox(getPt2(TEST_MOM), X^2 + Y^2)
+            @test isapprox(getPerp2(TEST_MOM), X^2 + Y^2)
+            @test isapprox(getTransverseMomentum(TEST_MOM), sqrt(X^2 + Y^2))
+            @test isapprox(getPt(TEST_MOM), sqrt(X^2 + Y^2))
+            @test isapprox(getPerp(TEST_MOM), sqrt(X^2 + Y^2))
+
+            @test isapprox(getTransverseMass2(TEST_MOM), E^2 - Z^2)
+            @test isapprox(getMt2(TEST_MOM), E^2 - Z^2)
+            @test isapprox(getTransverseMass(TEST_MOM), sqrt(E^2 - Z^2))
+            @test isapprox(getMt(TEST_MOM), sqrt(E^2 - Z^2))
+
+            @test isapprox(getRapidity(TEST_MOM), log((E + Z) / (E - Z)) / 2)
+        end
+
+        @testset "light cone" begin
+            @test isapprox(getPlus(TEST_MOM), (E + Z) / 2)
+            @test isapprox(getMinus(TEST_MOM), (E - Z) / 2)
+        end
+
+        @testset "type stability" begin
+            @testset "$fun" for fun in lorentz_getter
+                @test fun(TEST_MOM) isa dtype
+            end
+        end
+    end
+end


### PR DESCRIPTION
This fixes some implicit type casts in the accessor functions of the four-momentum interface. This also adds some unit tests to catch these type casts. 